### PR TITLE
New API key system with project id parameter

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -10,7 +10,9 @@ class Config
 {
     public const XML_PATH_ENRICH_ENABLED = 'catalog_ai/settings/active';
     public const XML_PATH_USE_ASYNC = 'catalog_ai/settings/async';
+    public const XML_PATH_OPENAI_ORGANIZATION_ID = 'catalog_ai/settings/openai_organization_id';
     public const XML_PATH_OPENAI_API_KEY = 'catalog_ai/settings/openai_key';
+    public const XML_PATH_OPENAI_PROJECT_ID = 'catalog_ai/settings/openai_project_id';
     public const XML_PATH_OPENAI_API_MODEL = 'catalog_ai/settings/openai_model';
     public const XML_PATH_OPENAI_API_MAX_TOKENS = 'catalog_ai/settings/openai_max_tokens';
     public const XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT = 'catalog_ai/advanced/system_prompt';
@@ -41,6 +43,21 @@ class Config
             self::XML_PATH_OPENAI_API_KEY
         );
     }
+
+    public function getOrganizationID(): mixed
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_ORGANIZATION_ID
+        );
+    }
+
+    public function getProjectId(): mixed
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_PROJECT_ID
+        );
+    }
+
     public function getApiModel(): mixed
     {
         return $this->scopeConfig->getValue(

--- a/Model/Config/Source/OpenAIModel.php
+++ b/Model/Config/Source/OpenAIModel.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use OpenAI;
+use OpenAI\Client as OpenAIClient;
+use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
+use Exception;
+
+class OpenAIModel implements OptionSourceInterface
+{
+    /**
+     * @var OpenAIClient|null
+     */
+    protected ?OpenAIClient $openAIclient = null;
+    /**
+     * @var OpenAI
+     */
+    protected OpenAI $openAI;
+    /**
+     * @var ModuleConfig
+     */
+    protected ModuleConfig $moduleConfig;
+
+    /**
+     * @param OpenAI $openAI
+     * @param ModuleConfig $moduleConfig
+     */
+    public function __construct(
+        OpenAI $openAI,
+        ModuleConfig $moduleConfig
+    ) {
+        $this->openAI = $openAI;
+        $this->moduleConfig = $moduleConfig;
+    }
+
+    /**
+     * @return void
+     */
+    protected function initClient()
+    {
+        $apiKey = $this->moduleConfig->getApiKey();
+        $organization = $this->moduleConfig->getOrganizationID();
+        $projectId = $this->moduleConfig->getProjectId();
+
+        $this->openAIclient = $this->openAI::client($apiKey, $organization, !empty($projectId) ? $projectId : null);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function toOptionArray(): array
+    {
+        $optionArray = [['value' => '', 'label' => __('-- Please Select --')]];
+
+        if (!empty($this->moduleConfig->getOrganizationID()) && !empty($this->moduleConfig->getApiKey())) {
+            try {
+                if (empty($this->openAIclient)) {
+                    $this->initClient();
+                }
+
+                $models = $this->openAIclient->models()->list()->toArray();
+
+                foreach ($models['data'] as $model) {
+                    $optionArray[] = [
+                        'value' => $model['id'],
+                        'label' => $model['id']
+                    ];
+                }
+            } catch (Exception $e) {
+                return $optionArray;
+            }
+
+        }
+
+        return $optionArray;
+    }
+}

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -18,7 +18,9 @@ class Enricher
         private readonly Config $config
     ) {
         $this->client = $this->clientFactory
+            ->withOrganization($this->config->getOrganizationId())
             ->withApiKey($this->config->getApiKey())
+            ->withProject($this->config->getProjectId())
             ->make();
     }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -28,6 +28,7 @@
                 <field id="openai_model" translate="label comment" type="select" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>OpenAI API Model</label>
                     <source_model>MageOS\CatalogDataAI\Model\Config\Source\OpenAIModel</source_model>
+                    <comment>Insert api key and organization ID and save to see options. Refer to the documentation to understand which model you should select: https://platform.openai.com/docs/models/overview</comment>
                 </field>
                 <field id="openai_max_tokens" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>OpenAI API Max Tokens</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -16,11 +16,18 @@
                     <label>Asynchronous enrichment</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="openai_organization_id" translate="label comment" sortOrder="20" showInDefault="1" canRestore="1">
+                    <label>OpenAI Organization ID</label>
+                </field>
                 <field id="openai_key" translate="label comment" type="password" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>OpenAI API key</label>
                 </field>
-                <field id="openai_model" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
+                <field id="openai_project_id" translate="label" sortOrder="35" showInDefault="1" canRestore="1">
+                    <label>Open AI Project ID</label>
+                </field>
+                <field id="openai_model" translate="label comment" type="select" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>OpenAI API Model</label>
+                    <source_model>MageOS\CatalogDataAI\Model\Config\Source\OpenAIModel</source_model>
                 </field>
                 <field id="openai_max_tokens" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>OpenAI API Max Tokens</label>


### PR DESCRIPTION
I added the organization_id and project_id parameters, which are required with API authentication system of OpenAI, now diversified projects.
I also added model selection from a select, powered by the API that provides the models available for the API key entered.
Version suggest for the tag: 0.3.0