### PR TITLE
Cast to string config output to be compatible with OpenAI sdk

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -37,30 +37,30 @@ class Config
         );
     }
 
-    public function getApiKey(): mixed
+    public function getApiKey(): string
     {
-        return $this->scopeConfig->getValue(
+        return (string)$this->scopeConfig->getValue(
             self::XML_PATH_OPENAI_API_KEY
         );
     }
 
-    public function getOrganizationID(): mixed
+    public function getOrganizationID(): string
     {
-        return $this->scopeConfig->getValue(
+        return (string)$this->scopeConfig->getValue(
             self::XML_PATH_OPENAI_ORGANIZATION_ID
         );
     }
 
-    public function getProjectId(): mixed
+    public function getProjectId(): string
     {
-        return $this->scopeConfig->getValue(
+        return (string)$this->scopeConfig->getValue(
             self::XML_PATH_OPENAI_PROJECT_ID
         );
     }
 
-    public function getApiModel(): mixed
+    public function getApiModel(): string
     {
-        return $this->scopeConfig->getValue(
+        return (string)$this->scopeConfig->getValue(
             self::XML_PATH_OPENAI_API_MODEL
         );
     }


### PR DESCRIPTION
I modified the type of the value returned by some configs, to force it to string type. This is to prevent it from returning a null type when the configs are empty and generating a TypeError during dependency injection compilation due to the OpenAI SDK mandatorily wanting the string type.
Suggested tag 0.3.1