### PR TITLE
add cli command to enrich a product by ID

### DIFF
--- a/Console/Command/EnrichCommand.php
+++ b/Console/Command/EnrichCommand.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Console\Command;
+
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CLI command to enrich product data using AI
+ */
+class EnrichCommand extends Command
+{
+    private const PRODUCT_ID_ARGUMENT = 'product_id';
+    private const OVERWRITE_ARGUMENT = 'overwrite';
+
+    public function __construct(
+        private readonly Enricher $enricher,
+        private readonly ProductRepository $productRepository,
+        private readonly StoreManagerInterface $storeManager,
+        string $name = null
+    ) {
+        parent::__construct($name);
+    }
+
+    /**
+     * Configure the command
+     */
+    protected function configure(): void
+    {
+        $this->setName('mageos-catalog-ai:enrich')
+            ->setDescription('Enrich product data using AI')
+            ->addArgument(
+                self::PRODUCT_ID_ARGUMENT,
+                InputArgument::REQUIRED,
+                'Product ID to enrich'
+            )
+            ->addArgument(
+                self::OVERWRITE_ARGUMENT,
+                InputArgument::OPTIONAL,
+                'Overwrite existing data (true|false)',
+                'false'
+            );
+    }
+
+    /**
+     * Execute the command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $productId = (int) $input->getArgument(self::PRODUCT_ID_ARGUMENT);
+        $overwriteArg = (string) $input->getArgument(self::OVERWRITE_ARGUMENT);
+
+        // Parse overwrite argument
+        $overwrite = $this->parseOverwriteFlag($overwriteArg);
+
+        $output->writeln("<info>Starting product enrichment for Product ID: {$productId}</info>");
+        $output->writeln("<info>Overwrite existing data: " . ($overwrite ? 'true' : 'false') . "</info>");
+
+        try {
+            // Set store to admin (same as Consumer)
+            $this->storeManager->setCurrentStore(0);
+
+            // Load the product
+            $product = $this->productRepository->getById($productId);
+
+            $output->writeln("<info>Loaded product: {$product->getName()}</info>");
+
+            // Set the overwrite flag (same as Consumer)
+            $product->setData('mageos_catalogai_overwrite', $overwrite);
+
+            // Execute the enrichment (same as Consumer)
+            $this->enricher->execute($product);
+
+            // Save the product (same as Consumer)
+            $this->productRepository->save($product);
+
+            $output->writeln("<info>Product enrichment completed successfully!</info>");
+
+            return Cli::RETURN_SUCCESS;
+
+        } catch (NoSuchEntityException $e) {
+            $output->writeln("<error>Product with ID {$productId} not found.</error>");
+            return Cli::RETURN_FAILURE;
+        } catch (\Exception $e) {
+            $output->writeln("<error>Error enriching product: {$e->getMessage()}</error>");
+            return Cli::RETURN_FAILURE;
+        }
+    }
+
+    /**
+     * Parse the overwrite flag from string input
+     */
+    private function parseOverwriteFlag(string $overwriteArg): bool
+    {
+        $normalizedArg = strtolower(trim($overwriteArg));
+
+        return in_array($normalizedArg, ['true', '1', 'yes', 'y'], true);
+    }
+}

--- a/Console/Command/EnrichCommand.php
+++ b/Console/Command/EnrichCommand.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Console\Command;
 
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 use Magento\Catalog\Model\ProductRepository;
+use Magento\Framework\App\State as AppState;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
@@ -25,6 +26,7 @@ class EnrichCommand extends Command
         private readonly Enricher $enricher,
         private readonly ProductRepository $productRepository,
         private readonly StoreManagerInterface $storeManager,
+        private readonly AppState $appState,
         string $name = null
     ) {
         parent::__construct($name);
@@ -65,6 +67,9 @@ class EnrichCommand extends Command
         $output->writeln("<info>Overwrite existing data: " . ($overwrite ? 'true' : 'false') . "</info>");
 
         try {
+            // Set area code to adminhtml for proper context
+            $this->appState->setAreaCode('adminhtml');
+
             // Set store to admin (same as Consumer)
             $this->storeManager->setCurrentStore(0);
 
@@ -104,4 +109,5 @@ class EnrichCommand extends Command
 
         return in_array($normalizedArg, ['true', '1', 'yes', 'y'], true);
     }
+
 }

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -1,0 +1,90 @@
+# MageOS Catalog Data AI - CLI Command
+
+## Overview
+
+This module now includes a CLI command to initiate product enrichment using AI, providing the same functionality as the message queue consumer but through a direct command-line interface.
+This feature was added to aid in debug of AI calls where message queue fails with status 4 or 6
+
+```
+$ php -d start_with_request=yes ./bin/magento mageos-catalog-ai:enrich 82511
+Starting product enrichment for Product ID: 82511
+Overwrite existing data: false
+Loaded product: BenQ Joybook R56 Series R56-BV04 Replacement Laptop Screen Panel
+Error enriching product: The "Manufacturer" attribute value is empty. Set the attribute and try again.
+```
+
+The above error was not logged during cron runs, but was logged during the CLI command.
+
+
+## Command Usage
+
+```bash
+./bin/magento mageos-catalog-ai:enrich [product_id] [overwrite]
+```
+
+### Parameters
+
+- `product_id` (required): The ID of the product to enrich
+- `overwrite` (optional): Whether to overwrite existing data. Accepts: `true`, `false`, `1`, `0`, `yes`, `no`, `y`, `n`. Default: `false`
+
+### Examples
+
+```bash
+# Enrich product with ID 104057, preserve existing data
+./bin/magento mageos-catalog-ai:enrich 104057
+
+# Enrich product with ID 104057, overwrite existing data
+./bin/magento mageos-catalog-ai:enrich 104057 true
+
+# Alternative overwrite formats
+./bin/magento mageos-catalog-ai:enrich 104057 yes
+./bin/magento mageos-catalog-ai:enrich 104057 1
+```
+
+## Implementation Details
+
+### Files Added
+
+1. **Console/Command/EnrichCommand.php** - Main CLI command class
+2. **etc/di.xml** - Dependency injection configuration to register the command
+
+### Functionality
+
+The CLI command replicates the exact same logic as the message queue consumer:
+
+1. Sets the store context to admin (store ID 0)
+2. Loads the product by ID
+3. Sets the overwrite flag on the product
+4. Executes the AI enrichment process
+5. Saves the product with enriched data
+
+### Error Handling
+
+The command includes comprehensive error handling:
+
+- **Product Not Found**: Returns appropriate error message if product ID doesn't exist
+- **Enrichment Errors**: Catches and displays any errors during the AI enrichment process
+- **Invalid Parameters**: Validates and parses input parameters
+
+### Attributes Enriched
+
+The command enriches the following product attributes using AI:
+
+- `short_description`
+- `description`
+- `meta_title`
+- `meta_keyword`
+- `meta_description`
+
+### Requirements
+
+- Product must have required attributes (e.g., manufacturer) populated for AI enrichment to work
+- OpenAI API configuration must be properly set up in the module configuration
+- Sufficient API credits/quota for OpenAI requests
+
+## Technical Notes
+
+- The command uses the same `Enricher` class as the message queue consumer
+- Rate limiting and backoff logic from the original enricher are preserved
+- Command follows Magento 2 CLI command best practices
+- Proper dependency injection for testability and maintainability

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -15,6 +15,14 @@ Error enriching product: The "Manufacturer" attribute value is empty. Set the at
 
 The above error was not logged during cron runs, but was logged during the CLI command.
 
+After successful:
+
+```
+Starting product enrichment for Product ID: 82511
+Overwrite existing data: false
+Loaded product: BenQ Joybook R56 Series R56-BV04 Replacement Laptop Screen Panel
+Product enrichment completed successfully!
+```
 
 ## Command Usage
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="mageos_catalog_ai_enrich" xsi:type="object">MageOS\CatalogDataAI\Console\Command\EnrichCommand</item>
+            </argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
This facilitated debugging why a product was going into status 6 in message queue with no reason logged anywhere

Run once via cli, reason was immediately obvious, so saves time. One can test on server, get error, and deal with whatever.



