### PR TITLE
meta_keyword not meta_keywords (plural)

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -50,7 +50,7 @@
                 <field id="meta_title" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>Meta Title</label>
                 </field>
-                <field id="meta_keywords" translate="label comment" type="textarea" sortOrder="50" showInDefault="1" canRestore="1">
+                <field id="meta_keyword" translate="label comment" type="textarea" sortOrder="50" showInDefault="1" canRestore="1">
                     <label>Meta Keywords</label>
                 </field>
                 <field id="meta_description" translate="label comment" type="textarea" sortOrder="60" showInDefault="1" canRestore="1">


### PR DESCRIPTION
Since core uses meta_keyword, teh code matching ai module attributes prompts don;t match up, as per code here: 

https://github.com/mage-os-lab/module-catalog-data-ai/blob/main/Model/Config.php#L76

after adjusted, meta_keyword field populates using example prompt:

```write a list of 10 seo product keywords for {{name}}. comma separated ```