### PR TITLE
add logging of prompt

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -10,6 +10,7 @@ class Config
 {
     public const XML_PATH_ENRICH_ENABLED = 'catalog_ai/settings/active';
     public const XML_PATH_USE_ASYNC = 'catalog_ai/settings/async';
+    public const XML_PATH_DEBUG_LOG = 'catalog_ai/settings/debug_log';
     public const XML_PATH_OPENAI_ORGANIZATION_ID = 'catalog_ai/settings/openai_organization_id';
     public const XML_PATH_OPENAI_API_KEY = 'catalog_ai/settings/openai_key';
     public const XML_PATH_OPENAI_PROJECT_ID = 'catalog_ai/settings/openai_project_id';
@@ -34,6 +35,13 @@ class Config
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_USE_ASYNC
+        );
+    }
+
+    public function isDebugLogEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_DEBUG_LOG
         );
     }
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Automatically Generate product descriptions and meta keywords with openAI, impro
 TL;DR: use `gpt-4o`
 
 You can use any [model](https://platform.openai.com/docs/guides/text?api-mode=chat#choosing-a-model) that supports chat completion api, as long as they support `developer` role message
+
+## Security Warning
+
+⚠️ **Important**: When Magento is running in developer mode, this module will log the complete prompts sent to the OpenAI API to the debug log. This may include sensitive product data such as names, descriptions, prices, and other product attributes. **Do not enable developer mode or debug logging on production environments** as this could expose sensitive business information in log files.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -72,6 +72,14 @@
                     <label>Presence Penalty</label>
                 </field>
             </group>
+            <group id="debug" translate="label" sortOrder="3000" showInDefault="1">
+                <label>Debug Settings</label>
+                <field id="debug_log" translate="label" type="select" sortOrder="25" showInDefault="1" canRestore="1">
+                    <label>Debug Log</label>
+                    <comment>Enable logging of AI prompts to log file.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,6 +16,9 @@
                 <frequency_penalty>0</frequency_penalty>
                 <presence_penalty>0</presence_penalty>
             </advanced>
+            <debug>
+                <debug_log>0</debug_log>
+            </debug>
         </catalog_ai>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="MageOS\CatalogDataAI\Model\Product\Enricher">
+        <arguments>
+            <argument name="customLogger" xsi:type="object">MageOS\CatalogDataAI\Logger\Logger</argument>
+        </arguments>
+    </type>
+
+    <virtualType name="MageOS\CatalogDataAI\Logger\Logger" type="Magento\Framework\Logger\Monolog">
+        <arguments>
+            <argument name="name" xsi:type="string">mageos-data-ai</argument>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">MageOS\CatalogDataAI\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="MageOS\CatalogDataAI\Logger\Handler" type="Magento\Framework\Logger\Handler\Base">
+        <arguments>
+            <argument name="fileName" xsi:type="string">/var/log/mageos-catalog-data-ai.log</argument>
+        </arguments>
+    </virtualType>
+</config>


### PR DESCRIPTION
During testing and prompt setup, I was getting back generated descriptions,  but they contained ID's in place of textuals. 
I was unsure if this was an AI (prompt) issue, or if the data being sent to AI is already wrong (ID based)

The change will log the prompt to be sent to AI to logs if in developer mode.

Also having ability to grab promt and use in a manual ai testing capacity is great.

example usage and result showed me that my issue is at the prompt generation. attributes are being passed as ID's

```
11:47 $ php -d xdebug.start_with_request=yes ./bin/magento mageos-catalog-ai:enrich 102170 true
Starting product enrichment for Product ID: 102170
Overwrite existing data: true
Loaded product: Asus G771JW-T7076T Replacement Laptop LCD Screen Panel
Product enrichment completed successfully!
```

in logs:
```
[2025-10-01T03:47:21.537622+00:00] main.DEBUG: CatalogDataAI: Sending prompt to OpenAI API {"attribute_code":"short_description","product_id":"102170","product_sku":"G771JW-T7076T","prompt":"Create a concise 2-3 sentence product summary focusing on compatibility.



Include: Screen size, resolution, connector type, and primary compatible brand/models.

Format: \"[Size]\" [Resolution] replacement screen for [Brand] laptops with [connector] connector. Compatible with: [key models]. [Screen finish] finish.\"



SPECIFICATIONS TO USE EXACTLY:

- Screen Size: 83\"  

- Resolution: 98

- Connector: 120

- Brand: Asus

- Screen Finish: 114

- Models: LP173WF4 SP D1 



Generate this content in html, starting with an h2 header element for the first title / heading and use <br/> for new lines"}
```

which was a clear indication where my issue lies.