### PR TITLE
Removed unused method

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -78,13 +78,6 @@ class Config
             $path
         );
     }
-    public function getProductPromptToken(string $attributeCode): mixed
-    {
-        $path = 'catalog_ai/product/' . $attributeCode;
-        return $this->scopeConfig->getValue(
-            $path
-        );
-    }
 
     public function canEnrich(Product $product): bool
     {


### PR DESCRIPTION
Fixes #26 -- there are no references to `getProductPromptToken()` in the module