### PR TITLE
Encrypt API key

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,8 +19,9 @@
                 <field id="openai_organization_id" translate="label comment" sortOrder="20" showInDefault="1" canRestore="1">
                     <label>OpenAI Organization ID</label>
                 </field>
-                <field id="openai_key" translate="label comment" type="password" sortOrder="30" showInDefault="1" canRestore="1">
+                <field id="openai_key" translate="label comment" type="obscure" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>OpenAI API key</label>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
                 <field id="openai_project_id" translate="label" sortOrder="35" showInDefault="1" canRestore="1">
                     <label>Open AI Project ID</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,10 @@
     <default>
         <catalog_ai>
             <settings>
-                <openai_model>gpt-3.5-turbo</openai_model>
+                <openai_organization_id />
+                <openai_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+                <openai_project_id />
+                <openai_model>gpt-4o</openai_model>
                 <openai_max_tokens>1000</openai_max_tokens>
             </settings>
             <product>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="catalog_ai/settings/openai_organization_id" xsi:type="string">1</item>
+                <item name="catalog_ai/settings/openai_key" xsi:type="string">1</item>
+                <item name="catalog_ai/settings/openai_project_id" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
Fixes #24 

This sets the OpenAI API key as encrypted. It should encrypt and decrypt the value automatically on load and save.

I also set the API connection info settings as sensitive, which means they won't be written to config.php via `app:config:dump`.

While I was in there, I changed the default model from `gpt-3.5-turbo` to `gpt-4o` since the readme says 'use `gpt-4o`'. If that's not proper, can undo it.