### PR TITLE
Make enrichment attributes configurable (#27)

### DIFF
--- a/Block/Adminhtml/Form/Field/AttributeColumn.php
+++ b/Block/Adminhtml/Form/Field/AttributeColumn.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
+use Magento\Framework\View\Element\Context;
+use Magento\Framework\View\Element\Html\Select;
+
+class AttributeColumn extends Select
+{
+    public function __construct(
+        Context $context,
+        private readonly CollectionFactory $attributeCollectionFactory,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+    }
+
+    public function setInputName($value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId($value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            $this->addOption('', (string)__('--Please Select--'));
+
+            $collection = $this->attributeCollectionFactory->create();
+            $collection->addFieldToFilter('frontend_input', ['in' => ['text', 'textarea', 'texteditor']]);
+            $collection->setOrder('frontend_label', 'ASC');
+
+            foreach ($collection as $attribute) {
+                $code = $attribute->getAttributeCode();
+                $label = $attribute->getFrontendLabel();
+                if ($label) {
+                    $this->addOption($code, sprintf('%s (%s)', $label, $code));
+                }
+            }
+        }
+
+        return parent::_toHtml();
+    }
+}

--- a/Block/Adminhtml/Form/Field/AttributeColumn.php
+++ b/Block/Adminhtml/Form/Field/AttributeColumn.php
@@ -27,13 +27,14 @@ class AttributeColumn extends Select
         return $this->setId($value);
     }
 
-    public function _toHtml(): string
+    protected function _toHtml(): string
     {
         if (!$this->getOptions()) {
             $this->addOption('', (string)__('--Please Select--'));
 
             $collection = $this->attributeCollectionFactory->create();
             $collection->addFieldToFilter('frontend_input', ['in' => ['text', 'textarea', 'texteditor']]);
+            $collection->addFieldToSelect(['attribute_code', 'frontend_label']);
             $collection->setOrder('frontend_label', 'ASC');
 
             foreach ($collection as $attribute) {

--- a/Block/Adminhtml/Form/Field/AttributePrompts.php
+++ b/Block/Adminhtml/Form/Field/AttributePrompts.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Element\BlockInterface;
+
+class AttributePrompts extends AbstractFieldArray
+{
+    private ?BlockInterface $attributeColumnRenderer = null;
+
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn('attribute_code', [
+            'label' => __('Attribute'),
+            'renderer' => $this->getAttributeColumnRenderer(),
+        ]);
+
+        $this->addColumn('prompt', [
+            'label' => __('Prompt'),
+            'class' => 'required-entry',
+        ]);
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Attribute');
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+
+        $attributeCode = $row->getData('attribute_code');
+        if ($attributeCode !== null) {
+            $key = 'option_' . $this->getAttributeColumnRenderer()->calcOptionHash($attributeCode);
+            $options[$key] = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getAttributeColumnRenderer(): AttributeColumn
+    {
+        if ($this->attributeColumnRenderer === null) {
+            $this->attributeColumnRenderer = $this->getLayout()->createBlock(
+                AttributeColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->attributeColumnRenderer;
+    }
+}

--- a/Block/Adminhtml/Form/Field/AttributePrompts.php
+++ b/Block/Adminhtml/Form/Field/AttributePrompts.php
@@ -10,6 +10,7 @@ use Magento\Framework\Exception\LocalizedException;
 class AttributePrompts extends AbstractFieldArray
 {
     private ?AttributeColumn $attributeColumnRenderer = null;
+    private ?PromptColumn $promptColumnRenderer = null;
 
     protected function _prepareToRender(): void
     {
@@ -20,7 +21,7 @@ class AttributePrompts extends AbstractFieldArray
 
         $this->addColumn('prompt', [
             'label' => __('Prompt'),
-            'class' => 'required-entry',
+            'renderer' => $this->getPromptColumnRenderer(),
         ]);
 
         $this->_addAfter = false;
@@ -57,5 +58,21 @@ class AttributePrompts extends AbstractFieldArray
         }
 
         return $this->attributeColumnRenderer;
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getPromptColumnRenderer(): PromptColumn
+    {
+        if ($this->promptColumnRenderer === null) {
+            $this->promptColumnRenderer = $this->getLayout()->createBlock(
+                PromptColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->promptColumnRenderer;
     }
 }

--- a/Block/Adminhtml/Form/Field/AttributePrompts.php
+++ b/Block/Adminhtml/Form/Field/AttributePrompts.php
@@ -6,11 +6,10 @@ namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
 use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\View\Element\BlockInterface;
 
 class AttributePrompts extends AbstractFieldArray
 {
-    private ?BlockInterface $attributeColumnRenderer = null;
+    private ?AttributeColumn $attributeColumnRenderer = null;
 
     protected function _prepareToRender(): void
     {

--- a/Block/Adminhtml/Form/Field/PromptColumn.php
+++ b/Block/Adminhtml/Form/Field/PromptColumn.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Framework\View\Element\AbstractBlock;
+
+class PromptColumn extends AbstractBlock
+{
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function setColumnName(string $value): self
+    {
+        return $this->setData('column_name', $value);
+    }
+
+    protected function _toHtml(): string
+    {
+        return sprintf(
+            '<textarea id="%s" name="%s" class="%s" style="width:100%%; min-height:80px;">%s</textarea>',
+            $this->escapeHtmlAttr($this->getId()),
+            $this->escapeHtmlAttr($this->getName()),
+            'required-entry',
+            $this->escapeHtml($this->getValue() ?? '')
+        );
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Catalog\Model\Product;
 
 class Config
@@ -22,7 +23,7 @@ class Config
     public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'catalog_ai/advanced/presence_penalty';
     public const XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS = 'catalog_ai/product/attribute_prompts';
 
-    private ?array $attributePromptsMap = null;
+    private array $attributePromptsMap = [];
 
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
@@ -76,17 +77,17 @@ class Config
         );
     }
 
-    public function getProductPrompt(string $attributeCode): ?string
+    public function getProductPrompt(string $attributeCode, ?int $storeId = null): ?string
     {
-        return $this->getAttributePromptsMap()[$attributeCode] ?? null;
+        return $this->getAttributePromptsMap($storeId)[$attributeCode] ?? null;
     }
 
     /**
      * @return string[] Attribute codes that have non-empty prompts configured.
      */
-    public function getConfiguredAttributes(): array
+    public function getConfiguredAttributes(?int $storeId = null): array
     {
-        return array_keys($this->getAttributePromptsMap());
+        return array_keys($this->getAttributePromptsMap($storeId));
     }
 
     public function canEnrich(Product $product): bool
@@ -130,26 +131,30 @@ class Config
      *
      * @return array<string, string>
      */
-    private function getAttributePromptsMap(): array
+    private function getAttributePromptsMap(?int $storeId = null): array
     {
-        if ($this->attributePromptsMap !== null) {
-            return $this->attributePromptsMap;
+        $cacheKey = $storeId ?? 'default';
+
+        if (isset($this->attributePromptsMap[$cacheKey])) {
+            return $this->attributePromptsMap[$cacheKey];
         }
 
-        $this->attributePromptsMap = [];
+        $this->attributePromptsMap[$cacheKey] = [];
 
-        $value = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS);
+        $value = $storeId !== null
+            ? $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS, ScopeInterface::SCOPE_STORES, $storeId)
+            : $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS);
 
         if (is_string($value)) {
             try {
                 $value = $this->json->unserialize($value);
             } catch (\InvalidArgumentException $e) {
-                return $this->attributePromptsMap;
+                return $this->attributePromptsMap[$cacheKey];
             }
         }
 
         if (!is_array($value)) {
-            return $this->attributePromptsMap;
+            return $this->attributePromptsMap[$cacheKey];
         }
 
         foreach ($value as $row) {
@@ -159,10 +164,10 @@ class Config
             $code = $row['attribute_code'] ?? '';
             $prompt = $row['prompt'] ?? '';
             if ($code !== '' && $prompt !== '') {
-                $this->attributePromptsMap[$code] = $prompt;
+                $this->attributePromptsMap[$cacheKey][$code] = $prompt;
             }
         }
 
-        return $this->attributePromptsMap;
+        return $this->attributePromptsMap[$cacheKey];
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MageOS\CatalogDataAI\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Catalog\Model\Product;
 
 class Config
@@ -19,9 +20,13 @@ class Config
     public const XML_PATH_OPENAI_API_ADVANCED_TEMPERATURE = 'catalog_ai/advanced/temperature';
     public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'catalog_ai/advanced/frequency_penalty';
     public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'catalog_ai/advanced/presence_penalty';
+    public const XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS = 'catalog_ai/product/attribute_prompts';
+
+    private ?array $attributePromptsMap = null;
 
     public function __construct(
-        private readonly ScopeConfigInterface $scopeConfig
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly Json $json
     ) {}
 
     public function isEnabled(): bool
@@ -71,12 +76,17 @@ class Config
         );
     }
 
-    public function getProductPrompt(string $attributeCode): mixed
+    public function getProductPrompt(string $attributeCode): ?string
     {
-        $path = 'catalog_ai/product/' . $attributeCode;
-        return $this->scopeConfig->getValue(
-            $path
-        );
+        return $this->getAttributePromptsMap()[$attributeCode] ?? null;
+    }
+
+    /**
+     * @return string[] Attribute codes that have non-empty prompts configured.
+     */
+    public function getConfiguredAttributes(): array
+    {
+        return array_keys($this->getAttributePromptsMap());
     }
 
     public function canEnrich(Product $product): bool
@@ -110,5 +120,49 @@ class Config
         return (float)$this->scopeConfig->getValue(
             self::XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY
         );
+    }
+
+    /**
+     * Parse the serialized attribute_prompts config into [attribute_code => prompt].
+     *
+     * Handles both the array format from config.xml defaults and the JSON string
+     * stored in the database by the ArraySerialized backend model.
+     *
+     * @return array<string, string>
+     */
+    private function getAttributePromptsMap(): array
+    {
+        if ($this->attributePromptsMap !== null) {
+            return $this->attributePromptsMap;
+        }
+
+        $this->attributePromptsMap = [];
+
+        $value = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS);
+
+        if (is_string($value)) {
+            try {
+                $value = $this->json->unserialize($value);
+            } catch (\InvalidArgumentException $e) {
+                return $this->attributePromptsMap;
+            }
+        }
+
+        if (!is_array($value)) {
+            return $this->attributePromptsMap;
+        }
+
+        foreach ($value as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $code = $row['attribute_code'] ?? '';
+            $prompt = $row['prompt'] ?? '';
+            if ($code !== '' && $prompt !== '') {
+                $this->attributePromptsMap[$code] = $prompt;
+            }
+        }
+
+        return $this->attributePromptsMap;
     }
 }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -33,9 +33,9 @@ class Enricher
         return $this->client;
     }
 
-    public function getAttributes(): array
+    public function getAttributes(?int $storeId = null): array
     {
-        return $this->config->getConfiguredAttributes();
+        return $this->config->getConfiguredAttributes($storeId);
     }
 
     /**
@@ -53,7 +53,7 @@ class Enricher
         if(!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)){
             return;
         }
-        if($prompt = $this->config->getProductPrompt($attributeCode)) {
+        if($prompt = $this->config->getProductPrompt($attributeCode, (int) $product->getStoreId())) {
             $parsedPrompt = $this->parsePrompt($prompt, $product);
 
             $response = $this->getClient()->chat()->create([
@@ -107,7 +107,7 @@ class Enricher
 
     public function execute(Product $product): void
     {
-        foreach ($this->getAttributes() as $attributeCode) {
+        foreach ($this->getAttributes((int) $product->getStoreId()) as $attributeCode) {
             try {
                 $this->enrichAttribute($product, $attributeCode);
             } catch (ErrorException $e) {

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -35,13 +35,7 @@ class Enricher
 
     public function getAttributes(): array
     {
-        return [
-            'short_description',
-            'description',
-            'meta_title',
-            'meta_keyword',
-            'meta_description',
-        ];
+        return $this->config->getConfiguredAttributes();
     }
 
     /**

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -44,7 +44,7 @@ class Enricher
     public function parsePrompt(string $prompt, Product $product): string
     {
         return preg_replace_callback('/\{\{(.+?)\}\}/', function ($matches) use ($product) {
-            return $product->getData($matches[1]);
+            return (string) ($product->getData($matches[1]) ?? '');
         }, $prompt);
     }
 
@@ -54,8 +54,7 @@ class Enricher
             return;
         }
         if($prompt = $this->config->getProductPrompt($attributeCode)) {
-
-            $prompt = $this->parsePrompt($prompt, $product);
+            $parsedPrompt = $this->parsePrompt($prompt, $product);
 
             $response = $this->getClient()->chat()->create([
                 'model' => $this->config->getApiModel(),
@@ -70,7 +69,7 @@ class Enricher
                     ],
                     [
                         'role' => 'user',
-                        'content' => $this->parsePrompt($prompt, $product)
+                        'content' => $parsedPrompt
                     ]
                 ]
             ]);

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Copyright © 2025 Mage-OS. All rights reserved.
+ */
+
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model;
+
+use InvalidArgumentException;
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    private ScopeConfigInterface&MockObject $scopeConfig;
+    private Json&MockObject $json;
+    private Config $config;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->json = $this->createMock(Json::class);
+        $this->config = new Config($this->scopeConfig, $this->json);
+    }
+
+    public function test_get_configured_attributes_reads_array_format_from_defaults(): void
+    {
+        $this->scopeConfig
+            ->method('getValue')
+            ->with(Config::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS)
+            ->willReturn([
+                'short_description' => ['attribute_code' => 'short_description', 'prompt' => 'foo'],
+                'description' => ['attribute_code' => 'description', 'prompt' => 'bar'],
+            ]);
+
+        $this->assertSame(
+            ['short_description', 'description'],
+            $this->config->getConfiguredAttributes()
+        );
+    }
+
+    public function test_get_configured_attributes_reads_json_format_from_db(): void
+    {
+        $serialized = '{"r1":{"attribute_code":"color","prompt":"p"}}';
+        $this->scopeConfig->method('getValue')->willReturn($serialized);
+        $this->json
+            ->expects($this->once())
+            ->method('unserialize')
+            ->with($serialized)
+            ->willReturn(['r1' => ['attribute_code' => 'color', 'prompt' => 'p']]);
+
+        $this->assertSame(['color'], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_configured_attributes_skips_rows_with_empty_attribute_code(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn([
+            'r1' => ['attribute_code' => '', 'prompt' => 'p'],
+            'r2' => ['attribute_code' => 'color', 'prompt' => 'p2'],
+        ]);
+
+        $this->assertSame(['color'], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_configured_attributes_skips_rows_with_empty_prompt(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn([
+            'r1' => ['attribute_code' => 'color', 'prompt' => ''],
+            'r2' => ['attribute_code' => 'size', 'prompt' => 'p'],
+        ]);
+
+        $this->assertSame(['size'], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_configured_attributes_skips_non_array_rows(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn([
+            'r1' => 'not-an-array',
+            'r2' => ['attribute_code' => 'color', 'prompt' => 'p'],
+        ]);
+
+        $this->assertSame(['color'], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_configured_attributes_returns_empty_for_null_value(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn(null);
+
+        $this->assertSame([], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_configured_attributes_returns_empty_for_malformed_json(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn('{not-json');
+        $this->json
+            ->method('unserialize')
+            ->willThrowException(new InvalidArgumentException('bad json'));
+
+        $this->assertSame([], $this->config->getConfiguredAttributes());
+    }
+
+    public function test_get_product_prompt_returns_configured_value(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn([
+            'r1' => ['attribute_code' => 'color', 'prompt' => 'extract color'],
+        ]);
+
+        $this->assertSame('extract color', $this->config->getProductPrompt('color'));
+    }
+
+    public function test_get_product_prompt_returns_null_for_unknown_attribute(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn([
+            'r1' => ['attribute_code' => 'color', 'prompt' => 'p'],
+        ]);
+
+        $this->assertNull($this->config->getProductPrompt('unknown'));
+    }
+
+    public function test_get_product_prompt_scopes_to_store_when_given(): void
+    {
+        $this->scopeConfig
+            ->expects($this->once())
+            ->method('getValue')
+            ->with(
+                Config::XML_PATH_PRODUCT_ATTRIBUTE_PROMPTS,
+                ScopeInterface::SCOPE_STORES,
+                42
+            )
+            ->willReturn([
+                'r1' => ['attribute_code' => 'color', 'prompt' => 'store-specific'],
+            ]);
+
+        $this->assertSame('store-specific', $this->config->getProductPrompt('color', 42));
+    }
+
+    public function test_results_are_cached_per_store_id(): void
+    {
+        $this->scopeConfig
+            ->expects($this->exactly(2))
+            ->method('getValue')
+            ->willReturnCallback(function (string $path, ?string $scope = null, $scopeId = null) {
+                return match ($scopeId) {
+                    42 => ['r1' => ['attribute_code' => 'color', 'prompt' => 'store42']],
+                    default => ['r1' => ['attribute_code' => 'color', 'prompt' => 'default']],
+                };
+            });
+
+        $this->assertSame('default', $this->config->getProductPrompt('color'));
+        $this->assertSame('default', $this->config->getProductPrompt('color'));
+        $this->assertSame('store42', $this->config->getProductPrompt('color', 42));
+        $this->assertSame('store42', $this->config->getProductPrompt('color', 42));
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="catalog_ai" translate="label" type="text" sortOrder="45" showInDefault="1">
+        <section id="catalog_ai" translate="label" type="text" sortOrder="45" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
             <label>AI Data Enrichment</label>
             <tab>catalog</tab>
@@ -35,7 +35,7 @@
                     <label>OpenAI API Max Tokens</label>
                 </field>
             </group>
-            <group id="product" translate="label" sortOrder="20" showInDefault="1" showInStore="1">
+            <group id="product" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Product Fields Auto-Generation</label>
                 <comment>
                     <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name}) as product attribute data placeholder
@@ -43,19 +43,19 @@
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
                 <field id="attribute_prompts" translate="label comment" sortOrder="10"
-                       showInDefault="1" showInStore="1" canRestore="1">
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Attribute Prompts</label>
                     <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributePrompts</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                     <comment><![CDATA[Select a product attribute and define the AI prompt. Use {{attribute_code}} as placeholders (e.g. {{name}}).]]></comment>
                 </field>
             </group>
-            <group id="advanced" translate="label" sortOrder="30" showInDefault="1">
+            <group id="advanced" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Advanced Settings</label>
-                <field id="system_prompt" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" canRestore="1">
+                <field id="system_prompt" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>System Prompt</label>
                 </field>
-                <field id="temperature" translate="label comment" type="select" sortOrder="20" showInDefault="1" canRestore="1">
+                <field id="temperature" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Temperature</label>
                     <options>
                         <option label="0.0 (most precise)">0</option>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -43,7 +43,7 @@
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
                 <field id="attribute_prompts" translate="label comment" sortOrder="10"
-                       showInDefault="1" canRestore="1">
+                       showInDefault="1" showInStore="1" canRestore="1">
                     <label>Attribute Prompts</label>
                     <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributePrompts</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -42,20 +42,12 @@
                     <br />
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
-                <field id="short_description" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" canRestore="1">
-                    <label>Short Description</label>
-                </field>
-                <field id="description" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" canRestore="1">
-                    <label>Description</label>
-                </field>
-                <field id="meta_title" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" canRestore="1">
-                    <label>Meta Title</label>
-                </field>
-                <field id="meta_keyword" translate="label comment" type="textarea" sortOrder="50" showInDefault="1" canRestore="1">
-                    <label>Meta Keywords</label>
-                </field>
-                <field id="meta_description" translate="label comment" type="textarea" sortOrder="60" showInDefault="1" canRestore="1">
-                    <label>Meta Description</label>
+                <field id="attribute_prompts" translate="label comment" sortOrder="10"
+                       showInDefault="1" showInStore="1" canRestore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributePrompts</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
+                    <comment><![CDATA[Select a product attribute and define the AI prompt. Use {{attribute_code}} as placeholders (e.g. {{name}}).]]></comment>
                 </field>
             </group>
             <group id="advanced" translate="label" sortOrder="30" showInDefault="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -43,7 +43,7 @@
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
                 <field id="attribute_prompts" translate="label comment" sortOrder="10"
-                       showInDefault="1" showInStore="1" canRestore="1">
+                       showInDefault="1" canRestore="1">
                     <label>Attribute Prompts</label>
                     <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributePrompts</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,8 +10,16 @@
                 <openai_max_tokens>1000</openai_max_tokens>
             </settings>
             <product>
-                <short_description>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</short_description>
-                <description>write a detailed product description for {{name}} with features in bullet list, under 1000 words</description>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute_code>short_description</attribute_code>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                    </short_description>
+                    <description>
+                        <attribute_code>description</attribute_code>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                    </description>
+                </attribute_prompts>
             </product>
             <advanced>
                 <system_prompt>Be a content generator, just reply with the content, skip all introductions.</system_prompt>


### PR DESCRIPTION
## Summary

- Replaces 5 hardcoded product attribute prompt fields with a dynamic row table, allowing admins to select any text-compatible product attribute and assign a custom AI prompt
- Adds `AttributeColumn` block that filters the attribute dropdown to `text`, `textarea`, and `texteditor` frontend input types
- Adds `AttributePrompts` dynamic row block with attribute dropdown + prompt text columns
- Refactors `Config` to parse the serialized config (handles both XML array defaults and JSON from DB) and expose `getConfiguredAttributes()` / `getProductPrompt()`
- `Enricher::getAttributes()` now delegates to `Config::getConfiguredAttributes()`
- Default config ships with `short_description` and `description` prompts (the 3 meta fields that had no defaults are omitted — admins can add them via the table)

Closes #27

## Test plan

- [ ] Run `bin/magento cache:flush` and load **Stores > Configuration > Catalog > AI Data Enrichment > Product Fields Auto-Generation**
- [ ] Verify the dynamic row table renders with 2 default rows (`short_description`, `description`)
- [ ] Add a new attribute row (e.g. `meta_title`), enter a prompt, save — verify it persists on reload
- [ ] Remove a row, save — verify it's gone on reload
- [ ] Create a new product and confirm enrichment runs only for configured attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)