### PR TITLE
Phase 2: Multi-Store/Locale + Enrichment Status Flags

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'single_quote' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    ])
+    ->setFinder($finder);

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;
@@ -7,7 +6,7 @@ namespace MageOS\CatalogDataAI\Api;
 interface RequestInterface
 {
     /**
-     * Retrieve products id.
+     * Retrieve product id.
      * @return int
      */
     public function getId(): int;
@@ -17,4 +16,10 @@ interface RequestInterface
      * @return bool
      */
     public function getOverwrite(): bool;
+
+    /**
+     * Retrieve store id.
+     * @return int
+     */
+    public function getStoreId(): int;
 }

--- a/Block/Adminhtml/Form/Field/AttributeColumn.php
+++ b/Block/Adminhtml/Form/Field/AttributeColumn.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\View\Element\Context;
+use Magento\Framework\View\Element\Html\Select;
+
+class AttributeColumn extends Select
+{
+    private array $attributeOptions = [];
+
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
+        ?Context $context = null,
+        array $data = []
+    ) {
+        if ($context !== null) {
+            parent::__construct($context, $data);
+        }
+    }
+
+    public function getOptions(): array
+    {
+        if (empty($this->attributeOptions)) {
+            $searchCriteria = $this->searchCriteriaBuilder
+                ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+                ->create();
+
+            $attributes = $this->attributeRepository->getList($searchCriteria);
+
+            foreach ($attributes->getItems() as $attribute) {
+                $this->attributeOptions[$attribute->getAttributeCode()] = $attribute->getDefaultFrontendLabel()
+                    ?? $attribute->getAttributeCode();
+            }
+
+            asort($this->attributeOptions);
+        }
+
+        return $this->attributeOptions;
+    }
+
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            $this->setOptions($this->getOptions());
+        }
+
+        foreach ($this->getOptions() as $code => $label) {
+            $this->addOption($code, $label);
+        }
+
+        return parent::_toHtml();
+    }
+}

--- a/Block/Adminhtml/Form/Field/ProductAttributes.php
+++ b/Block/Adminhtml/Form/Field/ProductAttributes.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class ProductAttributes extends AbstractFieldArray
+{
+    private ?AttributeColumn $attributeRenderer = null;
+
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn('attribute', [
+            'label' => __('Attribute'),
+            'renderer' => $this->getAttributeRenderer(),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('prompt', [
+            'label' => __('Prompt'),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('enabled', [
+            'label' => __('Enabled'),
+            'class' => 'required-entry',
+        ]);
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Attribute');
+    }
+
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+        $attribute = $row->getData('attribute');
+
+        if ($attribute !== null) {
+            $key = 'option_' . $this->getAttributeRenderer()->calcOptionHash($attribute);
+            $options[$key] = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getAttributeRenderer(): AttributeColumn
+    {
+        if ($this->attributeRenderer === null) {
+            $this->attributeRenderer = $this->getLayout()->createBlock(
+                AttributeColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->attributeRenderer;
+    }
+}

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
 
+use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Backend\App\Action;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
@@ -41,7 +42,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
-        if($this->config->isEnabled()) {
+        if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
@@ -54,8 +55,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
                     __('A total of %1 record(s) are scheduled to get data enriched.', $productEnriched)
                 );
             }
-        }
-        else {
+        } else {
             $this->messageManager->addErrorMessage(
                 __('Data enrichment is disabled. Please enable it in the configuration.')
             );

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Ui\Component\MassAction\Filter;
 use MageOS\CatalogDataAI\Model\Config;
+use Magento\Store\Model\StoreManagerInterface;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
 class MassEnrich extends Action implements HttpPostActionInterface
@@ -27,6 +28,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         private readonly Config                     $config,
         private readonly Publisher                  $publisher,
         private readonly ProductRepositoryInterface $productRepository,
+        private readonly StoreManagerInterface $storeManager,
     ) {
         parent::__construct($context);
     }
@@ -42,11 +44,12 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
+        $storeId = (int)$this->storeManager->getStore()->getId();
         if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
-                $this->publisher->execute($product->getId(), $this->overwrite);
+                $this->publisher->execute($product->getId(), $this->overwrite, $storeId);
                 $productEnriched++;
             }
 

--- a/Controller/Adminhtml/Product/MassEnrichSafe.php
+++ b/Controller/Adminhtml/Product/MassEnrichSafe.php
@@ -1,9 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
-
-use MageOS\CatalogDataAI\Controller\Adminhtml\Product\MassEnrich;
 
 class MassEnrichSafe extends MassEnrich
 {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -21,6 +21,21 @@ class Config
     public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'catalog_ai/advanced/frequency_penalty';
     public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'catalog_ai/advanced/presence_penalty';
 
+    private const LOCALE_LANGUAGE_MAP = [
+        'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
+        'ca' => 'Catalan', 'cs' => 'Czech', 'cy' => 'Welsh', 'da' => 'Danish',
+        'de' => 'German', 'el' => 'Greek', 'en' => 'English', 'es' => 'Spanish',
+        'et' => 'Estonian', 'fa' => 'Persian', 'fi' => 'Finnish', 'fr' => 'French',
+        'gl' => 'Galician', 'he' => 'Hebrew', 'hi' => 'Hindi', 'hr' => 'Croatian',
+        'hu' => 'Hungarian', 'id' => 'Indonesian', 'it' => 'Italian', 'ja' => 'Japanese',
+        'ka' => 'Georgian', 'ko' => 'Korean', 'lt' => 'Lithuanian', 'lv' => 'Latvian',
+        'mk' => 'Macedonian', 'ms' => 'Malay', 'nb' => 'Norwegian', 'nl' => 'Dutch',
+        'pl' => 'Polish', 'pt' => 'Portuguese', 'ro' => 'Romanian', 'ru' => 'Russian',
+        'sk' => 'Slovak', 'sl' => 'Slovenian', 'sq' => 'Albanian', 'sr' => 'Serbian',
+        'sv' => 'Swedish', 'th' => 'Thai', 'tr' => 'Turkish', 'uk' => 'Ukrainian',
+        'vi' => 'Vietnamese', 'zh' => 'Chinese',
+    ];
+
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig
     ) {
@@ -105,11 +120,27 @@ class Config
         return $this->isEnabled() && $this->getApiKey() && $product->isObjectNew();
     }
 
-    public function getSystemPrompt(): mixed
+    public function getSystemPrompt(): string
     {
-        return $this->scopeConfig->getValue(
-            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT
+        $basePrompt = (string)$this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
+
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        if ($locale) {
+            $langCode = substr($locale, 0, 2);
+            $language = self::LOCALE_LANGUAGE_MAP[$langCode] ?? null;
+            if ($language && $langCode !== 'en') {
+                $basePrompt = 'Respond in ' . $language . '. ' . $basePrompt;
+            }
+        }
+
+        return $basePrompt;
     }
 
     public function getTemperature(): float

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Config
 {
@@ -22,7 +23,8 @@ class Config
 
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig
-    ) {}
+    ) {
+    }
 
     public function isEnabled(): bool
     {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -73,12 +73,31 @@ class Config
         );
     }
 
-    public function getProductPrompt(string $attributeCode): mixed
+    public function getEnrichableAttributes(): array
     {
-        $path = 'catalog_ai/product/' . $attributeCode;
-        return $this->scopeConfig->getValue(
-            $path
+        $rows = $this->scopeConfig->getValue(
+            'catalog_ai/product/attribute_prompts'
         );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach ($rows as $row) {
+            if (isset($row['attribute'], $row['prompt'], $row['enabled']) && (int)$row['enabled'] === 1) {
+                $attributes[$row['attribute']] = $row['prompt'];
+            }
+        }
+
+        return $attributes;
+    }
+
+    public function getProductPrompt(string $attributeCode): ?string
+    {
+        $attributes = $this->getEnrichableAttributes();
+
+        return $attributes[$attributeCode] ?? null;
     }
 
     public function canEnrich(Product $product): bool

--- a/Model/Config/Source/OpenAIModel.php
+++ b/Model/Config/Source/OpenAIModel.php
@@ -2,11 +2,11 @@
 
 namespace MageOS\CatalogDataAI\Model\Config\Source;
 
+use Exception;
 use Magento\Framework\Data\OptionSourceInterface;
+use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
 use OpenAI;
 use OpenAI\Client as OpenAIClient;
-use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
-use Exception;
 
 class OpenAIModel implements OptionSourceInterface
 {

--- a/Model/EnrichmentLog.php
+++ b/Model/EnrichmentLog.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class EnrichmentLog extends AbstractModel
+{
+    public const STATUS_GENERATED = 'generated';
+    public const STATUS_PENDING_REVIEW = 'pending_review';
+    public const STATUS_MODIFIED = 'modified';
+
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLogResource::class);
+    }
+}

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -7,30 +6,25 @@ namespace MageOS\CatalogDataAI\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\Store\Model\StoreManagerInterface;
 
-/**
- * Class Consumer
- * @package Gaiterjones\RabbitMQ\MessageQueues\Product
- */
 class Consumer
 {
-    /**
-     * Consumer constructor.
-     */
     public function __construct(
-        private readonly Enricher          $enricher,
-        private readonly ProductRepository $productRepository,
+        private readonly Enricher              $enricher,
+        private readonly ProductRepository     $productRepository,
         private readonly StoreManagerInterface $storeManager
     ) {
     }
 
     public function execute(Request $request): void
     {
-        // @TODO: enrich for all stores if different value or language
-        $this->storeManager->setCurrentStore(0);
-        $product = $this->productRepository->getById($request->getId());
+        $this->storeManager->setCurrentStore($request->getStoreId());
+        $product = $this->productRepository->getById(
+            $request->getId(),
+            false,
+            $request->getStoreId()
+        );
         $product->setData('mageos_catalogai_overwrite', $request->getOverwrite());
         $this->enricher->execute($product);
         $this->productRepository->save($product);
     }
-
 }

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -19,7 +20,8 @@ class Consumer
         private readonly Enricher          $enricher,
         private readonly ProductRepository $productRepository,
         private readonly StoreManagerInterface $storeManager
-    ) {}
+    ) {
+    }
 
     public function execute(Request $request): void
     {

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product;
 use MageOS\CatalogDataAI\Model\Config;
 use OpenAI\Client;
 use OpenAI\Exceptions\ErrorException;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 use OpenAI\Factory;
 use OpenAI\Responses\Meta\MetaInformation;
 
@@ -17,7 +18,8 @@ class Enricher
 
     public function __construct(
         private readonly Factory $clientFactory,
-        private readonly Config $config
+        private readonly Config $config,
+        private readonly EnrichmentLogger $enrichmentLogger
     ) {
     }
 
@@ -79,6 +81,11 @@ class Enricher
             // @TODO:  no exception?
             if ($result = $response->choices[0]) {
                 $product->setData($attributeCode, $result->message?->content);
+                $this->enrichmentLogger->log(
+                    (int)$product->getId(),
+                    $attributeCode,
+                    (int)$product->getStoreId()
+                );
             }
             $this->backoff($response->meta());
         }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -56,10 +57,10 @@ class Enricher
 
     public function enrichAttribute(Product $product, string $attributeCode): void
     {
-        if(!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)){
+        if (!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)) {
             return;
         }
-        if($prompt = $this->config->getProductPrompt($attributeCode)) {
+        if ($prompt = $this->config->getProductPrompt($attributeCode)) {
 
             $prompt = $this->parsePrompt($prompt, $product);
 
@@ -82,7 +83,7 @@ class Enricher
             ]);
 
             // @TODO:  no exception?
-            if($result = $response->choices[0]) {
+            if ($result = $response->choices[0]) {
                 $product->setData($attributeCode, $result->message?->content);
             }
             $this->backoff($response->meta());
@@ -91,12 +92,12 @@ class Enricher
 
     public function backoff(MetaInformation $meta): void
     {
-        if($meta->requestLimit->remaining < 1) {
+        if ($meta->requestLimit->remaining < 1) {
             sleep($this->strToSeconds($meta->requestLimit->reset));
         }
         // 1 token ~= 0.75 word
         // do not use config value
-        if($meta->tokenLimit->remaining < 1000) {
+        if ($meta->tokenLimit->remaining < 1000) {
             sleep($this->strToSeconds($meta->tokenLimit->reset));
         }
     }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -36,13 +36,7 @@ class Enricher
 
     public function getAttributes(): array
     {
-        return [
-            'short_description',
-            'description',
-            'meta_title',
-            'meta_keyword',
-            'meta_description',
-        ];
+        return array_keys($this->config->getEnrichableAttributes());
     }
 
     /**

--- a/Model/Product/EnrichmentLogger.php
+++ b/Model/Product/EnrichmentLogger.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class EnrichmentLogger
+{
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogFactory $logFactory,
+        private readonly EnrichmentLogResource $resource
+    ) {
+    }
+
+    public function log(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId()) {
+            $existing->setData('status', EnrichmentLog::STATUS_GENERATED);
+            $this->resource->save($existing);
+        } else {
+            $log = $this->logFactory->create();
+            $log->setData([
+                'entity_id' => $entityId,
+                'attribute_code' => $attributeCode,
+                'store_id' => $storeId,
+                'status' => EnrichmentLog::STATUS_GENERATED,
+            ]);
+            $this->resource->save($log);
+        }
+    }
+
+    public function markModified(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId() && $existing->getData('status') !== EnrichmentLog::STATUS_MODIFIED) {
+            $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
+            $this->resource->save($existing);
+        }
+    }
+
+    public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        return $existing->getId() ? $existing->getData('status') : null;
+    }
+
+    public function getStatusesForProduct(int $entityId, int $storeId): array
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        $statuses = [];
+        foreach ($collection as $item) {
+            $statuses[$item->getData('attribute_code')] = $item->getData('status');
+        }
+
+        return $statuses;
+    }
+
+    private function find(int $entityId, string $attributeCode, int $storeId): EnrichmentLog
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getFirstItem();
+    }
+}

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -19,15 +19,12 @@ class Publisher
     ) {
     }
 
-    /**
-     * @param int|string $productId
-     * @param bool $overwrite
-     */
-    public function execute(int|string $productId, bool $overwrite = false): void
+    public function execute(int|string $productId, bool $overwrite = false, int $storeId = 0): void
     {
         $request = $this->requestFactory->create([
             'id' => (int)$productId,
-            'overwrite' => $overwrite
+            'overwrite' => $overwrite,
+            'storeId' => $storeId,
         ]);
         $this->publisher->publish(self::TOPIC_NAME, $request);
     }

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -1,14 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
 
 use Magento\Framework\MessageQueue\PublisherInterface;
-use MageOS\CatalogDataAI\Model\Product\RequestFactory;
 
 class Publisher
 {
-    const TOPIC_NAME = 'mageos.product.enrich';
+    public const TOPIC_NAME = 'mageos.product.enrich';
 
     /**
      * Publisher constructor.
@@ -16,7 +16,8 @@ class Publisher
     public function __construct(
         private readonly PublisherInterface $publisher,
         private readonly RequestFactory     $requestFactory,
-    ) {}
+    ) {
+    }
 
     /**
      * @param int|string $productId

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -13,23 +12,23 @@ class Request implements RequestInterface
 {
     public function __construct(
         private readonly int $id,
-        private readonly bool $overwrite
+        private readonly bool $overwrite,
+        private readonly int $storeId = 0
     ) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOverwrite(): bool
     {
         return $this->overwrite;
+    }
+
+    public function getStoreId(): int
+    {
+        return $this->storeId;
     }
 }

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/ResourceModel/EnrichmentLog.php
+++ b/Model/ResourceModel/EnrichmentLog.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class EnrichmentLog extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_enrichment_log', 'log_id');
+    }
+}

--- a/Model/ResourceModel/EnrichmentLog/Collection.php
+++ b/Model/ResourceModel/EnrichmentLog/Collection.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLog::class, EnrichmentLogResource::class);
+    }
+}

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -24,7 +24,11 @@ class SaveAfter implements ObserverInterface
         $product = $observer->getProduct();
 
         if ($this->config->canEnrich($product) && $this->config->isAsync()) {
-            $this->publisher->execute($product->getId(), false);
+            $this->publisher->execute(
+                $product->getId(),
+                false,
+                (int)$product->getStoreId()
+            );
         }
     }
 }

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
@@ -14,14 +15,15 @@ class SaveAfter implements ObserverInterface
     public function __construct(
         private readonly Config $config,
         private readonly Publisher $publisher
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
         /** @var Product $product */
         $product = $observer->getProduct();
 
-        if($this->config->canEnrich($product) && $this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && $this->config->isAsync()) {
             $this->publisher->execute($product->getId(), false);
         }
     }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 
@@ -14,14 +15,15 @@ class SaveBefore implements ObserverInterface
     public function __construct(
         private readonly Config $config,
         private readonly Enricher $enricher
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
         /** @var Product $product */
         $product = $observer->getProduct();
 
-        if($this->config->canEnrich($product) && !$this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
             $this->enricher->execute($product);
         }
     }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
@@ -9,12 +8,14 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 
 class SaveBefore implements ObserverInterface
 {
     public function __construct(
         private readonly Config $config,
-        private readonly Enricher $enricher
+        private readonly Enricher $enricher,
+        private readonly EnrichmentLogger $enrichmentLogger
     ) {
     }
 
@@ -25,6 +26,29 @@ class SaveBefore implements ObserverInterface
 
         if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
             $this->enricher->execute($product);
+            return;
+        }
+
+        if (!$product->isObjectNew() && $product->getId()) {
+            $this->detectManualEdits($product);
+        }
+    }
+
+    private function detectManualEdits(Product $product): void
+    {
+        $storeId = (int)$product->getStoreId();
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            if (!$product->dataHasChangedFor($attributeCode)) {
+                continue;
+            }
+
+            $this->enrichmentLogger->markModified(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId
+            );
         }
     }
 }

--- a/Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
+++ b/Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class MigrateProductPromptsToDynamicRows implements DataPatchInterface
+{
+    private const OLD_ATTRIBUTE_PATHS = [
+        'short_description',
+        'description',
+        'meta_title',
+        'meta_keyword',
+        'meta_description',
+    ];
+
+    private const NEW_PATH = 'catalog_ai/product/attribute_prompts';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter,
+        private readonly Json $json
+    ) {
+    }
+
+    public function apply(): self
+    {
+        $rows = [];
+        $hasExistingConfig = false;
+
+        foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+            $oldPath = 'catalog_ai/product/' . $attributeCode;
+            $value = $this->scopeConfig->getValue($oldPath);
+
+            if ($value !== null && $value !== '') {
+                $hasExistingConfig = true;
+                $rows[$attributeCode] = [
+                    'attribute' => $attributeCode,
+                    'prompt' => $value,
+                    'enabled' => '1',
+                ];
+            }
+        }
+
+        if ($hasExistingConfig) {
+            $this->configWriter->save(self::NEW_PATH, $this->json->serialize($rows));
+
+            // Clean up old paths
+            foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+                $this->configWriter->delete('catalog_ai/product/' . $attributeCode);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+++ b/Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Block\Adminhtml\Form\Field;
+
+use MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributeColumn;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchResultsInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeColumnTest extends TestCase
+{
+    public function test_get_options_returns_text_and_textarea_attributes(): void
+    {
+        $attribute1 = $this->createMock(ProductAttributeInterface::class);
+        $attribute1->method('getAttributeCode')->willReturn('description');
+        $attribute1->method('getDefaultFrontendLabel')->willReturn('Description');
+
+        $attribute2 = $this->createMock(ProductAttributeInterface::class);
+        $attribute2->method('getAttributeCode')->willReturn('short_description');
+        $attribute2->method('getDefaultFrontendLabel')->willReturn('Short Description');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$attribute1, $attribute2]);
+
+        $searchCriteria = $this->createMock(SearchCriteria::class);
+
+        $searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $attributeRepository = $this->createMock(ProductAttributeRepositoryInterface::class);
+        $attributeRepository->method('getList')->willReturn($searchResults);
+
+        $column = new AttributeColumn($attributeRepository, $searchCriteriaBuilder);
+        $options = $column->getOptions();
+
+        $this->assertArrayHasKey('description', $options);
+        $this->assertArrayHasKey('short_description', $options);
+        $this->assertEquals('Description', $options['description']);
+        $this->assertEquals('Short Description', $options['short_description']);
+    }
+}

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model;
 
 use MageOS\CatalogDataAI\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
@@ -27,8 +28,9 @@ final class ConfigTest extends TestCase
         ];
 
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn($serializedData);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
 
         $result = $this->config->getEnrichableAttributes();
 
@@ -36,15 +38,14 @@ final class ConfigTest extends TestCase
         $this->assertArrayHasKey('description', $result);
         $this->assertArrayHasKey('short_description', $result);
         $this->assertArrayNotHasKey('meta_title', $result);
-        $this->assertEquals('describe {{name}}', $result['description']);
-        $this->assertEquals('short desc for {{name}}', $result['short_description']);
     }
 
     public function test_get_enrichable_attributes_returns_empty_when_null(): void
     {
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn(null);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
 
         $result = $this->config->getEnrichableAttributes();
 
@@ -59,10 +60,38 @@ final class ConfigTest extends TestCase
         ];
 
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn($serializedData);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
 
         $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
         $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+
+    public function test_get_system_prompt_includes_locale_language(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'fr_FR'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertStringContainsString('Respond in French', $result);
+        $this->assertStringContainsString('Be a content generator.', $result);
+    }
+
+    public function test_get_system_prompt_skips_locale_for_english(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'en_US'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertEquals('Be a content generator.', $result);
     }
 }

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model;
+
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    private ScopeConfigInterface $scopeConfig;
+    private Config $config;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->config = new Config($this->scopeConfig);
+    }
+
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+        $this->assertEquals('describe {{name}}', $result['description']);
+        $this->assertEquals('short desc for {{name}}', $result['short_description']);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn(null);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+}

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
 
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 use Magento\Catalog\Model\Product;
 use OpenAI\Factory;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +21,8 @@ final class EnricherTest extends TestCase
         ]);
 
         $factory = $this->createMock(Factory::class);
-        $enricher = new Enricher($factory, $config);
+        $logger = $this->createMock(EnrichmentLogger::class);
+        $enricher = new Enricher($factory, $config, $logger);
 
         $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
     }
@@ -29,7 +31,8 @@ final class EnricherTest extends TestCase
     {
         $config = $this->createMock(Config::class);
         $factory = $this->createMock(Factory::class);
-        $enricher = new Enricher($factory, $config);
+        $logger = $this->createMock(EnrichmentLogger::class);
+        $enricher = new Enricher($factory, $config, $logger);
 
         $product = $this->createMock(Product::class);
         $product->method('getData')

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use Magento\Catalog\Model\Product;
+use OpenAI\Factory;
+use PHPUnit\Framework\TestCase;
+
+final class EnricherTest extends TestCase
+{
+    public function test_get_attributes_returns_enabled_attribute_codes_from_config(): void
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('getEnrichableAttributes')->willReturn([
+            'description' => 'describe {{name}}',
+            'custom_field' => 'generate {{name}} custom',
+        ]);
+
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
+    }
+
+    public function test_parse_prompt_replaces_placeholders_with_product_data(): void
+    {
+        $config = $this->createMock(Config::class);
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $product = $this->createMock(Product::class);
+        $product->method('getData')
+            ->willReturnMap([
+                ['name', null, 'Cool Widget'],
+                ['price', null, '29.99'],
+            ]);
+
+        $result = $enricher->parsePrompt('describe {{name}} at {{price}}', $product);
+
+        $this->assertEquals('describe Cool Widget at 29.99', $result);
+    }
+}

--- a/Test/Unit/Model/Product/EnrichmentLoggerTest.php
+++ b/Test/Unit/Model/Product/EnrichmentLoggerTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class EnrichmentLoggerTest extends TestCase
+{
+    public function test_log_creates_new_entry_when_none_exists(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($this->createConfiguredMock(
+            EnrichmentLog::class,
+            ['getId' => null]
+        ));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $newLog = $this->createMock(EnrichmentLog::class);
+        $newLog->expects($this->once())->method('setData')->with($this->callback(
+            fn(array $data) => $data['entity_id'] === 42
+                && $data['attribute_code'] === 'description'
+                && $data['store_id'] === 1
+                && $data['status'] === EnrichmentLog::STATUS_GENERATED
+        ));
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $logFactory->method('create')->willReturn($newLog);
+
+        $resource = $this->createMock(EnrichmentLogResource::class);
+        $resource->expects($this->once())->method('save')->with($newLog);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $logger->log(42, 'description', 1);
+    }
+}

--- a/Test/Unit/Model/Product/RequestTest.php
+++ b/Test/Unit/Model/Product/RequestTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_request_carries_store_id(): void
+    {
+        $request = new Request(42, true, 3);
+
+        $this->assertEquals(42, $request->getId());
+        $this->assertTrue($request->getOverwrite());
+        $this->assertEquals(3, $request->getStoreId());
+    }
+
+    public function test_store_id_defaults_to_zero(): void
+    {
+        $request = new Request(42, false);
+
+        $this->assertEquals(0, $request->getStoreId());
+    }
+}

--- a/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
+++ b/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\Framework\Stdlib\ArrayManager;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class EnrichmentStatus extends AbstractModifier
+{
+    public function __construct(
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly Config $config,
+        private readonly ArrayManager $arrayManager
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            $containerPath = $this->arrayManager->findPath(
+                $attributeCode,
+                $meta,
+                null,
+                'children'
+            );
+
+            if ($containerPath) {
+                $meta = $this->arrayManager->merge(
+                    $containerPath . '/arguments/data/config',
+                    $meta,
+                    [
+                        'additionalClasses' => 'mageos-catalogai-enriched-field',
+                    ]
+                );
+            }
+        }
+
+        return $meta;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
             "homepage": "https://www.sunmerce.com/"
         }
     ],
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://mirror.mage-os.org"
-        }
-    ],
     "require": {
         "php": "^8.1",
-        "openai-php/client": "*"
+        "openai-php/client": "*",
+        "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-ui": "*",
+        "magento/module-backend": "*",
+        "magento/module-config": "*",
+        "magento/module-store": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/docs/plans/2026-04-14-feature-roadmap-design.md
+++ b/docs/plans/2026-04-14-feature-roadmap-design.md
@@ -1,0 +1,133 @@
+# Feature Roadmap Design — MageOS_CatalogDataAI
+
+**Date:** 2026-04-14
+**Approach:** Quick Wins, Then Depth
+**BC policy:** Pragmatic — data patches for migration, old paths can break, documented in release notes
+
+---
+
+## Phase 1: Housekeeping + Configurable Attributes
+
+**Issues:** #23, #22, #25, #27
+
+### Housekeeping
+
+- Run PHP-CS-Fixer with PSR-12/Magento rules across all files
+- Fix `system.xml` temperature field: change label from "System Prompt" to "Temperature", add `<comment>` tags to all advanced fields explaining valid ranges
+- Fix `composer.json`: add explicit Magento module dependencies (`magento/framework`, `magento/module-catalog`, `magento/module-ui`, `magento/module-backend`), remove the mirror repository entry, keep `phpunit` in require-dev
+
+### Configurable Attributes
+
+Replace the hardcoded attribute list and static `system.xml` fields with a dynamic row configuration.
+
+- **New admin config**: Replace the 5 fixed textarea fields under "Product Fields Auto-Generation" with a dynamic row table with columns:
+  - **Attribute** — dropdown of product text/textarea attributes
+  - **Prompt** — textarea for the prompt template
+  - **Enabled** — yes/no toggle per attribute
+- **Data patch**: Migrate existing `catalog_ai/product/*` config values into the new dynamic row format
+- **Enricher refactor**: `getAttributes()` reads from the dynamic config instead of returning a hardcoded array. `enrichAttribute()` stays the same — it already takes an attribute code and looks up the prompt from config
+- **Config model**: `getProductPrompt()` adapts to read from the serialized dynamic row data instead of individual config paths
+- **Default rows**: Pre-populate the same 5 attributes (short_description, description, meta_title, meta_keyword, meta_description) with their current default prompts
+
+---
+
+## Phase 2: Multi-Store/Locale + Enrichment Status Flags
+
+**Issues:** #12, #48
+
+### Multi-Store/Locale
+
+- **Locale-aware prompts**: Detect the store's locale (`general/locale/code`) and prepend "Respond in {locale language}" to the system prompt when enriching for a store
+- **Store-scoped enrichment**: `Publisher`/`Request` DTO gets a `storeId` field. `Consumer` sets the correct store scope before enriching so config values resolve per-store. Mass actions enrich for the selected store scope
+- **Data patch**: Add `storeId` to the `Request` queue message format with default of `0` for backward compatibility with in-flight messages
+
+### Enrichment Status Flags
+
+- **New DB table**: `mageos_catalogai_enrichment_log` with columns: `entity_id` (product ID), `attribute_code`, `store_id`, `status` (enum: `generated`, `pending_review`, `modified`), `generated_at`, `updated_at`
+- **Write on enrich**: When `Enricher` successfully sets an attribute value, write/update a log row with status `generated`
+- **Detect manual edits**: In `SaveBefore` observer, if an enriched attribute's value changed and it wasn't the enricher doing it, flip status to `modified`
+- **Admin UI indicator**: On the product edit form, add a small badge/note next to enriched fields showing their status via a UI component modifier
+- No blocking review workflow yet — that's Phase 4. This phase just tracks and displays status.
+
+---
+
+## Phase 3: Prompt Rules Engine + Config Migration
+
+**Issues:** #32, #43
+
+### Prompt Rules Engine
+
+- **New admin grid**: "AI Prompt Rules" grid. Each rule has:
+  - **Name** — human-readable label
+  - **Attribute** — which attribute this prompt targets
+  - **Store scope(s)** — multiselect, default: all
+  - **Conditions** — product conditions using Magento's existing condition engine (same as catalog price rules)
+  - **Prompt** — template with `{{variable}}` support
+  - **Priority** — integer, highest wins
+  - **Enabled** — yes/no
+- **Rule resolution**: Collect all matching enabled rules for attribute+store, sort by priority, use highest. Fall back to default prompt from Phase 1's dynamic rows if no rule matches.
+- **Preview/test**: On the rule edit form, "Test" button — enter a SKU, see the resolved prompt + API response
+- **Storage**: New DB tables for rules and conditions (entities, not config)
+- **Phase 1 compatibility**: Dynamic row config becomes "default prompts" — rules layer on top, no migration needed
+
+### Config Migration
+
+- **New section**: `ai_integration` under the Services tab, matching the translation module's structure
+- **Group**: "Data Enrichment" group within that section
+- **Data patch**: Migrate all `catalog_ai/*` config values to the new path
+- **No legacy path support** — document in release notes
+
+---
+
+## Phase 4: Review/Approval Workflow
+
+**Issues:** #28
+
+### Enrichment Review Grid
+
+- **Admin grid**: "AI Enrichment Review" under the AI Integration section. Columns: product name/SKU, attribute, store, status, generated content (truncated), generated date. Filterable by status, store, attribute.
+- **Inline editing**: Admin clicks into a row to see full content, edit, approve, or reject
+- **Statuses expand**: Phase 2 statuses gain `approved` and `rejected`. Rejected clears or reverts the attribute value.
+- **Original value backup**: Before enrichment overwrites, store the previous value in the log table for revert on rejection
+- **Review mode config**: Toggle "Require review before publish". When enabled:
+  - Enricher writes to log with `pending_review` but does NOT set on the product
+  - Admin approves in grid -> content written to product and saved
+- **Bulk grid actions**: Approve selected, reject selected, re-generate selected
+
+### Content Deduplication
+
+- **Hash tracking**: Compute hash of resolved prompt (after variable substitution), store in log alongside generated output
+- **Cache hit**: Before calling OpenAI, check for existing log entry with same prompt hash + attribute + store. Reuse if found.
+- **Cache invalidation**: Prompt or source data changes -> hash won't match -> fresh API call. No manual cache management.
+
+---
+
+## Phase 5: Structured Attribute Extraction
+
+**Issues:** #7
+
+### Attribute Extraction
+
+- **New enrichment type**: "Attribute Extraction" alongside "Content Generation". Separate config/rules — prompt engineering is fundamentally different (extract/classify vs. create).
+- **Attribute mapping config**: Admin defines extraction rules:
+  - **Source attribute(s)** — where to read from (e.g., description)
+  - **Target attribute** — attribute to fill (dropdown, multiselect, boolean, text, decimal)
+  - **Extraction prompt** — instructions for the AI
+  - **Value mapping** — for dropdowns/multiselects: map AI output strings to option IDs, supports fuzzy matching
+  - **Conditions** — reuse Phase 3 conditions engine
+- **Structured output**: Use OpenAI's JSON mode (`response_format: { type: "json_object" }`) for reliable structured responses
+- **Validation**: Validate extracted value against attribute constraints before writing. Log failures.
+- **Review integration**: Extracted values go through Phase 4 review flow, defaulting to `pending_review` status
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|---|---|
+| Keep per-attribute API calls (not unified) | Per-attribute prompts give more control, especially with the rules engine where different attributes may need completely different prompts per store/category/language |
+| Pragmatic BC, no legacy config paths | Avoids carrying dead weight; data patches handle migration cleanly |
+| Dynamic rows before rules engine | Dynamic rows is a quick win that unblocks configurable attributes; rules engine layers on top later |
+| Config migration paired with rules engine | Both touch prompt storage/admin structure — one release reshuffles the admin experience |
+| Review workflow as Phase 4 | Needs the enrichment log from Phase 2 and benefits from the rules engine in Phase 3 |
+| Structured extraction last | Most experimental feature, benefits from all prior infrastructure (rules, review, configurable attributes) |

--- a/docs/plans/2026-04-14-phase1-implementation.md
+++ b/docs/plans/2026-04-14-phase1-implementation.md
@@ -1,0 +1,879 @@
+# Phase 1: Housekeeping + Configurable Attributes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix code style, composer deps, and system.xml label issues, then replace the hardcoded 5-attribute enrichment list with a dynamic row configuration that lets admins enrich any text attribute.
+
+**Architecture:** The dynamic rows feature replaces the static `catalog_ai/product/*` config fields with a single serialized field using Magento's `AbstractFieldArray` + `ArraySerialized` backend model. A custom select renderer provides an attribute dropdown. The `Config` model and `Enricher` are updated to read from the new serialized format. A data patch migrates existing config.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, PHPUnit 9.5
+
+---
+
+### Task 1: Fix composer.json
+
+**Files:**
+- Modify: `composer.json`
+
+**Step 1: Update composer.json**
+
+Replace the entire content of `composer.json` with:
+
+```json
+{
+    "name": "mage-os/module-catalog-data-ai",
+    "description": "Generate product descriptions and similar content with the help of AI.",
+    "type": "magento2-module",
+    "license": [
+        "MIT"
+    ],
+    "authors": [
+        {
+            "name": "Ryan Sun",
+            "email": "ryansun81@gmail.com",
+            "homepage": "https://www.sunmerce.com/"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "openai-php/client": "*",
+        "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-ui": "*",
+        "magento/module-backend": "*",
+        "magento/module-config": "*",
+        "magento/module-store": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "MageOS\\CatalogDataAI\\": ""
+        }
+    }
+}
+```
+
+Changes from current:
+- Removed `repositories` block (the mage-os mirror is not needed for the package itself)
+- Added explicit Magento module dependencies: `magento/framework`, `magento/module-catalog`, `magento/module-ui`, `magento/module-backend`, `magento/module-config`, `magento/module-store`
+
+**Step 2: Commit**
+
+```bash
+git add composer.json
+git commit -m "fix: add explicit Magento module dependencies, remove mirror repo (#22)"
+```
+
+---
+
+### Task 2: Fix system.xml labels and comments
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml:62-75`
+
+**Step 1: Fix the temperature label and add comments to advanced fields**
+
+In `etc/adminhtml/system.xml`, replace the `advanced` group (lines 61-76) with:
+
+```xml
+            <group id="advanced" translate="label" sortOrder="30" showInDefault="1">
+                <label>Advanced Settings</label>
+                <field id="system_prompt" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
+                    <label>System Prompt</label>
+                    <comment><![CDATA[Instructions sent to the AI model as the developer/system role. Defines the AI's behavior.]]></comment>
+                </field>
+                <field id="temperature" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
+                    <label>Temperature</label>
+                    <comment><![CDATA[Controls randomness. 0.0 = deterministic, 1.0 = creative. Default: 0]]></comment>
+                </field>
+                <field id="frequency_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
+                    <label>Frequency Penalty</label>
+                    <comment><![CDATA[Reduces repetition of token sequences. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+                <field id="presence_penalty" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
+                    <label>Presence Penalty</label>
+                    <comment><![CDATA[Encourages new topics. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+            </group>
+```
+
+Key changes:
+- Temperature `<label>` changed from "System Prompt" to "Temperature"
+- Added `<comment>` to all 4 advanced fields explaining valid ranges
+- Presence penalty `sortOrder` changed from `30` to `40` (was duplicate)
+
+**Step 2: Commit**
+
+```bash
+git add etc/adminhtml/system.xml
+git commit -m "fix: correct temperature label, add range comments to advanced fields (#25)"
+```
+
+---
+
+### Task 3: Run PHP-CS-Fixer
+
+**Files:**
+- Modify: all `.php` files
+
+**Step 1: Install PHP-CS-Fixer (if not available globally)**
+
+```bash
+composer global require friendsofphp/php-cs-fixer --dev
+```
+
+**Step 2: Create a `.php-cs-fixer.dist.php` config at module root**
+
+Create file `.php-cs-fixer.dist.php`:
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'single_quote' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    ])
+    ->setFinder($finder);
+```
+
+**Step 3: Run the fixer**
+
+```bash
+php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff
+```
+
+Review the diff to make sure nothing weird happened. The changes should be whitespace, brace placement, and import ordering only.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "style: apply PSR-12 code style fixes (#23)"
+```
+
+---
+
+### Task 4: Create the attribute column select renderer
+
+**Files:**
+- Create: `Block/Adminhtml/Form/Field/AttributeColumn.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Block\Adminhtml\Form\Field;
+
+use MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributeColumn;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchResultsInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeColumnTest extends TestCase
+{
+    public function test_get_options_returns_text_and_textarea_attributes(): void
+    {
+        $attribute1 = $this->createMock(ProductAttributeInterface::class);
+        $attribute1->method('getAttributeCode')->willReturn('description');
+        $attribute1->method('getDefaultFrontendLabel')->willReturn('Description');
+
+        $attribute2 = $this->createMock(ProductAttributeInterface::class);
+        $attribute2->method('getAttributeCode')->willReturn('short_description');
+        $attribute2->method('getDefaultFrontendLabel')->willReturn('Short Description');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$attribute1, $attribute2]);
+
+        $searchCriteria = $this->createMock(SearchCriteria::class);
+
+        $searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $attributeRepository = $this->createMock(ProductAttributeRepositoryInterface::class);
+        $attributeRepository->method('getList')->willReturn($searchResults);
+
+        $column = new AttributeColumn($attributeRepository, $searchCriteriaBuilder);
+        $options = $column->getOptions();
+
+        $this->assertArrayHasKey('description', $options);
+        $this->assertArrayHasKey('short_description', $options);
+        $this->assertEquals('Description', $options['description']);
+        $this->assertEquals('Short Description', $options['short_description']);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+```
+
+Expected: FAIL — class `AttributeColumn` does not exist.
+
+**Step 3: Write the implementation**
+
+Create file `Block/Adminhtml/Form/Field/AttributeColumn.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\View\Element\Html\Select;
+use Magento\Framework\View\Element\Context;
+
+class AttributeColumn extends Select
+{
+    private array $options = [];
+
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
+        Context $context = null,
+        array $data = []
+    ) {
+        // Context may be null in unit tests
+        if ($context !== null) {
+            parent::__construct($context, $data);
+        }
+    }
+
+    public function getOptions(): array
+    {
+        if (empty($this->options)) {
+            $searchCriteria = $this->searchCriteriaBuilder
+                ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+                ->create();
+
+            $attributes = $this->attributeRepository->getList($searchCriteria);
+
+            foreach ($attributes->getItems() as $attribute) {
+                $this->options[$attribute->getAttributeCode()] = $attribute->getDefaultFrontendLabel()
+                    ?? $attribute->getAttributeCode();
+            }
+
+            asort($this->options);
+        }
+
+        return $this->options;
+    }
+
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            $this->setOptions($this->getOptions());
+        }
+
+        foreach ($this->getOptions() as $code => $label) {
+            $this->addOption($code, $label);
+        }
+
+        return parent::_toHtml();
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Block/Adminhtml/Form/Field/AttributeColumn.php Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+git commit -m "feat: add attribute column select renderer for dynamic rows (#27)"
+```
+
+---
+
+### Task 5: Create the dynamic rows field array block
+
+**Files:**
+- Create: `Block/Adminhtml/Form/Field/ProductAttributes.php`
+
+**Step 1: Write the implementation**
+
+This block is mostly wiring — Magento's `AbstractFieldArray` does the heavy lifting. No meaningful unit test possible without the full layout system.
+
+Create file `Block/Adminhtml/Form/Field/ProductAttributes.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class ProductAttributes extends AbstractFieldArray
+{
+    private ?AttributeColumn $attributeRenderer = null;
+
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn('attribute', [
+            'label' => __('Attribute'),
+            'renderer' => $this->getAttributeRenderer(),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('prompt', [
+            'label' => __('Prompt'),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('enabled', [
+            'label' => __('Enabled'),
+            'class' => 'required-entry',
+        ]);
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Attribute');
+    }
+
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+        $attribute = $row->getData('attribute');
+
+        if ($attribute !== null) {
+            $key = 'option_' . $this->getAttributeRenderer()->calcOptionHash($attribute);
+            $options[$key] = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getAttributeRenderer(): AttributeColumn
+    {
+        if ($this->attributeRenderer === null) {
+            $this->attributeRenderer = $this->getLayout()->createBlock(
+                AttributeColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->attributeRenderer;
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Block/Adminhtml/Form/Field/ProductAttributes.php
+git commit -m "feat: add dynamic rows field array block for product attributes (#27)"
+```
+
+---
+
+### Task 6: Update system.xml — replace static fields with dynamic rows
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml:38-59`
+
+**Step 1: Replace the product group**
+
+In `etc/adminhtml/system.xml`, replace the entire `product` group (lines 38-59) with:
+
+```xml
+            <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
+                <label>Product Fields Auto-Generation</label>
+                <comment>
+                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name) as product attribute data placeholder.
+                    <br />
+                    To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
+                </comment>
+                <field id="attribute_prompts" translate="label" sortOrder="10" showInDefault="1" showInStore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\ProductAttributes</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
+                </field>
+            </group>
+```
+
+This replaces the 5 individual textarea fields with a single dynamic rows field.
+
+**Step 2: Commit**
+
+```bash
+git add etc/adminhtml/system.xml
+git commit -m "feat: replace static product fields with dynamic rows config (#27)"
+```
+
+---
+
+### Task 7: Update config.xml — default values in dynamic row format
+
+**Files:**
+- Modify: `etc/config.xml:11-15`
+
+**Step 1: Replace the product defaults**
+
+In `etc/config.xml`, replace the `<product>` block (lines 11-15) with:
+
+```xml
+            <product>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute>short_description</attribute>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                        <enabled>1</enabled>
+                    </short_description>
+                    <description>
+                        <attribute>description</attribute>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                        <enabled>1</enabled>
+                    </description>
+                    <meta_title>
+                        <attribute>meta_title</attribute>
+                        <prompt>write a concise SEO meta title for {{name}}, under 60 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_title>
+                    <meta_keyword>
+                        <attribute>meta_keyword</attribute>
+                        <prompt>generate comma-separated SEO keywords for {{name}}, max 10 keywords</prompt>
+                        <enabled>1</enabled>
+                    </meta_keyword>
+                    <meta_description>
+                        <attribute>meta_description</attribute>
+                        <prompt>write an SEO meta description for {{name}}, under 160 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_description>
+                </attribute_prompts>
+            </product>
+```
+
+Note: `meta_title`, `meta_keyword`, and `meta_description` previously had no default prompts. We're adding sensible defaults now since the dynamic rows format requires a prompt value per row.
+
+**Step 2: Commit**
+
+```bash
+git add etc/config.xml
+git commit -m "feat: add default dynamic row values for all 5 enrichable attributes (#27)"
+```
+
+---
+
+### Task 8: Update Config model to read dynamic rows
+
+**Files:**
+- Modify: `Model/Config.php:74-80`
+- Test: `Test/Unit/Model/ConfigTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/ConfigTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model;
+
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    private ScopeConfigInterface $scopeConfig;
+    private Config $config;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->config = new Config($this->scopeConfig);
+    }
+
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+        $this->assertEquals('describe {{name}}', $result['description']);
+        $this->assertEquals('short desc for {{name}}', $result['short_description']);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn(null);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/ConfigTest.php
+```
+
+Expected: FAIL — `getEnrichableAttributes` method does not exist.
+
+**Step 3: Update Config model**
+
+In `Model/Config.php`, replace the `getProductPrompt` method (lines 74-80) with two new methods:
+
+```php
+    public function getEnrichableAttributes(): array
+    {
+        $rows = $this->scopeConfig->getValue(
+            'catalog_ai/product/attribute_prompts'
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach ($rows as $row) {
+            if (isset($row['attribute'], $row['prompt'], $row['enabled']) && (int)$row['enabled'] === 1) {
+                $attributes[$row['attribute']] = $row['prompt'];
+            }
+        }
+
+        return $attributes;
+    }
+
+    public function getProductPrompt(string $attributeCode): ?string
+    {
+        $attributes = $this->getEnrichableAttributes();
+
+        return $attributes[$attributeCode] ?? null;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/ConfigTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "feat: update Config to read attribute prompts from dynamic rows (#27)"
+```
+
+---
+
+### Task 9: Update Enricher to use dynamic config
+
+**Files:**
+- Modify: `Model/Product/Enricher.php:36-45`
+- Test: `Test/Unit/Model/Product/EnricherTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/EnricherTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Catalog\Model\Product;
+use OpenAI\Factory;
+use PHPUnit\Framework\TestCase;
+
+final class EnricherTest extends TestCase
+{
+    public function test_get_attributes_returns_enabled_attribute_codes_from_config(): void
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('getEnrichableAttributes')->willReturn([
+            'description' => 'describe {{name}}',
+            'custom_field' => 'generate {{name}} custom',
+        ]);
+
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
+    }
+
+    public function test_parse_prompt_replaces_placeholders_with_product_data(): void
+    {
+        $config = $this->createMock(Config::class);
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $product = $this->createMock(Product::class);
+        $product->method('getData')
+            ->willReturnMap([
+                ['name', null, 'Cool Widget'],
+                ['price', null, '29.99'],
+            ]);
+
+        $result = $enricher->parsePrompt('describe {{name}} at {{price}}', $product);
+
+        $this->assertEquals('describe Cool Widget at 29.99', $result);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/Product/EnricherTest.php
+```
+
+Expected: FAIL — `getAttributes()` returns hardcoded array, not config-driven.
+
+**Step 3: Update Enricher**
+
+In `Model/Product/Enricher.php`, replace the `getAttributes` method (lines 36-45) with:
+
+```php
+    public function getAttributes(): array
+    {
+        return array_keys($this->config->getEnrichableAttributes());
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/Product/EnricherTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Model/Product/Enricher.php Test/Unit/Model/Product/EnricherTest.php
+git commit -m "feat: Enricher reads attribute list from dynamic config (#27)"
+```
+
+---
+
+### Task 10: Create data patch to migrate existing config
+
+**Files:**
+- Create: `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php`
+
+**Step 1: Write the data patch**
+
+Create file `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+
+class MigrateProductPromptsToDynamicRows implements DataPatchInterface
+{
+    private const OLD_ATTRIBUTE_PATHS = [
+        'short_description',
+        'description',
+        'meta_title',
+        'meta_keyword',
+        'meta_description',
+    ];
+
+    private const NEW_PATH = 'catalog_ai/product/attribute_prompts';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter,
+        private readonly Json $json
+    ) {
+    }
+
+    public function apply(): self
+    {
+        $rows = [];
+        $hasExistingConfig = false;
+
+        foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+            $oldPath = 'catalog_ai/product/' . $attributeCode;
+            $value = $this->scopeConfig->getValue($oldPath);
+
+            if ($value !== null && $value !== '') {
+                $hasExistingConfig = true;
+                $rows[$attributeCode] = [
+                    'attribute' => $attributeCode,
+                    'prompt' => $value,
+                    'enabled' => '1',
+                ];
+            }
+        }
+
+        if ($hasExistingConfig) {
+            $this->configWriter->save(self::NEW_PATH, $this->json->serialize($rows));
+
+            // Clean up old paths
+            foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+                $this->configWriter->delete('catalog_ai/product/' . $attributeCode);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
+git commit -m "feat: add data patch to migrate old product prompts to dynamic rows (#27)"
+```
+
+---
+
+### Task 11: Smoke test — setup:upgrade and di:compile
+
+**Step 1: Run Magento setup commands**
+
+From the Magento root directory:
+
+```bash
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+```
+
+Both should complete without errors. If `di:compile` fails, check the constructor signatures in the new block classes — Magento's DI compiler is strict about type hints.
+
+**Step 2: Verify in admin**
+
+1. Go to **Stores > Configuration > Catalog > AI Data Enrichment > Product Fields Auto-Generation**
+2. Verify the dynamic rows table renders with the 5 default attributes
+3. Verify the attribute dropdown loads product text/textarea attributes
+4. Try adding a new row, saving, and reloading — confirm persistence
+
+**Step 3: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+Expected: All tests pass.
+
+**Step 4: Final commit (if any adjustments were needed)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 1"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| Modify | `composer.json` |
+| Modify | `etc/adminhtml/system.xml` |
+| Modify | `etc/config.xml` |
+| Modify | `Model/Config.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Create | `.php-cs-fixer.dist.php` |
+| Create | `Block/Adminhtml/Form/Field/AttributeColumn.php` |
+| Create | `Block/Adminhtml/Form/Field/ProductAttributes.php` |
+| Create | `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php` |
+| Create | `Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php` |
+| Create | `Test/Unit/Model/ConfigTest.php` |
+| Create | `Test/Unit/Model/Product/EnricherTest.php` |

--- a/docs/plans/2026-04-14-phase2-implementation.md
+++ b/docs/plans/2026-04-14-phase2-implementation.md
@@ -1,0 +1,1106 @@
+# Phase 2: Multi-Store/Locale + Enrichment Status Flags — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add store-scoped enrichment with locale-aware AI output, and track which product attributes were AI-generated with status indicators in the admin product edit form.
+
+**Architecture:** The `Request` DTO gains a `storeId` field so queue messages carry store context. `Consumer` sets the store scope before enriching, and `Config` resolves the store's locale to inject language instructions into the system prompt. A new `mageos_catalogai_enrichment_log` DB table tracks enrichment status per product/attribute/store. The `Enricher` writes log entries on successful enrichment, and a `SaveBefore` observer detects manual edits to enriched fields. A UI component modifier adds status badges to the product edit form.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, PHPUnit 9.5, Magento Declarative Schema (`db_schema.xml`)
+
+---
+
+### Task 1: Add storeId to RequestInterface and Request DTO
+
+**Files:**
+- Modify: `Api/RequestInterface.php`
+- Modify: `Model/Product/Request.php`
+- Test: `Test/Unit/Model/Product/RequestTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/RequestTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_request_carries_store_id(): void
+    {
+        $request = new Request(42, true, 3);
+
+        $this->assertEquals(42, $request->getId());
+        $this->assertTrue($request->getOverwrite());
+        $this->assertEquals(3, $request->getStoreId());
+    }
+
+    public function test_store_id_defaults_to_zero(): void
+    {
+        $request = new Request(42, false);
+
+        $this->assertEquals(0, $request->getStoreId());
+    }
+}
+```
+
+**Step 2: Update RequestInterface**
+
+In `Api/RequestInterface.php`, add the `getStoreId` method to the interface:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api;
+
+interface RequestInterface
+{
+    /**
+     * Retrieve product id.
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * Retrieve overwrite flag.
+     * @return bool
+     */
+    public function getOverwrite(): bool;
+
+    /**
+     * Retrieve store id.
+     * @return int
+     */
+    public function getStoreId(): int;
+}
+```
+
+**Step 3: Update Request DTO**
+
+Replace `Model/Product/Request.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Api\RequestInterface;
+
+/**
+ * Data model for enrichment message queue.
+ */
+class Request implements RequestInterface
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly bool $overwrite,
+        private readonly int $storeId = 0
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getOverwrite(): bool
+    {
+        return $this->overwrite;
+    }
+
+    public function getStoreId(): int
+    {
+        return $this->storeId;
+    }
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add Api/RequestInterface.php Model/Product/Request.php Test/Unit/Model/Product/RequestTest.php
+git commit -m "feat: add storeId to Request DTO for store-scoped enrichment (#12)"
+```
+
+---
+
+### Task 2: Update Publisher to pass storeId
+
+**Files:**
+- Modify: `Model/Product/Publisher.php`
+
+**Step 1: Update Publisher::execute signature and pass storeId to Request**
+
+Replace `Model/Product/Publisher.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Framework\MessageQueue\PublisherInterface;
+
+class Publisher
+{
+    public const TOPIC_NAME = 'mageos.product.enrich';
+
+    public function __construct(
+        private readonly PublisherInterface $publisher,
+        private readonly RequestFactory     $requestFactory,
+    ) {
+    }
+
+    public function execute(int|string $productId, bool $overwrite = false, int $storeId = 0): void
+    {
+        $request = $this->requestFactory->create([
+            'id' => (int)$productId,
+            'overwrite' => $overwrite,
+            'storeId' => $storeId,
+        ]);
+        $this->publisher->publish(self::TOPIC_NAME, $request);
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Publisher.php
+git commit -m "feat: Publisher passes storeId to queue messages (#12)"
+```
+
+---
+
+### Task 3: Update Consumer to set store scope
+
+**Files:**
+- Modify: `Model/Product/Consumer.php`
+
+**Step 1: Update Consumer to use storeId from request**
+
+Replace `Model/Product/Consumer.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Consumer
+{
+    public function __construct(
+        private readonly Enricher              $enricher,
+        private readonly ProductRepository     $productRepository,
+        private readonly StoreManagerInterface $storeManager
+    ) {
+    }
+
+    public function execute(Request $request): void
+    {
+        $this->storeManager->setCurrentStore($request->getStoreId());
+        $product = $this->productRepository->getById(
+            $request->getId(),
+            false,
+            $request->getStoreId()
+        );
+        $product->setData('mageos_catalogai_overwrite', $request->getOverwrite());
+        $this->enricher->execute($product);
+        $this->productRepository->save($product);
+    }
+}
+```
+
+Key changes:
+- Uses `$request->getStoreId()` instead of hardcoded `0`
+- Passes `storeId` to `getById()` third parameter so product data loads for the correct store
+- Removed the stale `@package` docblock
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Consumer.php
+git commit -m "feat: Consumer sets store scope from queue message (#12)"
+```
+
+---
+
+### Task 4: Update SaveAfter observer to pass storeId
+
+**Files:**
+- Modify: `Observer/Product/SaveAfter.php`
+
+**Step 1: Pass the product's store ID to the publisher**
+
+In `Observer/Product/SaveAfter.php`, change the `execute` method to pass the store ID:
+
+```php
+    public function execute(Observer $observer): void
+    {
+        /** @var Product $product */
+        $product = $observer->getProduct();
+
+        if ($this->config->canEnrich($product) && $this->config->isAsync()) {
+            $this->publisher->execute(
+                $product->getId(),
+                false,
+                (int)$product->getStoreId()
+            );
+        }
+    }
+```
+
+**Step 2: Commit**
+
+```bash
+git add Observer/Product/SaveAfter.php
+git commit -m "feat: SaveAfter observer passes storeId to publisher (#12)"
+```
+
+---
+
+### Task 5: Update MassEnrich controller to pass storeId
+
+**Files:**
+- Modify: `Controller/Adminhtml/Product/MassEnrich.php`
+
+**Step 1: Inject StoreManagerInterface and pass current store to publisher**
+
+Add `StoreManagerInterface` to the constructor and pass the current store ID in the loop:
+
+In the constructor, add after `ProductRepositoryInterface`:
+```php
+        private readonly \Magento\Store\Model\StoreManagerInterface $storeManager,
+```
+
+In the `execute()` method, before the foreach loop, get the current store:
+```php
+        $storeId = (int)$this->storeManager->getStore()->getId();
+```
+
+In the foreach loop, change:
+```php
+                $this->publisher->execute($product->getId(), $this->overwrite);
+```
+to:
+```php
+                $this->publisher->execute($product->getId(), $this->overwrite, $storeId);
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/Product/MassEnrich.php
+git commit -m "feat: MassEnrich passes current store scope to publisher (#12)"
+```
+
+---
+
+### Task 6: Add locale-aware system prompt to Config
+
+**Files:**
+- Modify: `Model/Config.php`
+- Test: `Test/Unit/Model/ConfigTest.php`
+
+**Step 1: Write the test**
+
+Add this test to the existing `Test/Unit/Model/ConfigTest.php`:
+
+```php
+    public function test_get_system_prompt_includes_locale_language(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'fr_FR'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertStringContainsString('Respond in French', $result);
+        $this->assertStringContainsString('Be a content generator.', $result);
+    }
+
+    public function test_get_system_prompt_without_locale_returns_base_prompt(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertEquals('Be a content generator.', $result);
+    }
+```
+
+Add this import at the top of the test file:
+```php
+use Magento\Store\Model\ScopeInterface;
+```
+
+Also update the `setUp()` method — the existing tests use `->method('getValue')->with(...)` which will conflict with the new `willReturnMap`. The tests need to be refactored. Replace the two existing `getEnrichableAttributes` tests and the `getProductPrompt` test so they also use `willReturnMap`:
+
+```php
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+```
+
+**Step 2: Update Config::getSystemPrompt()**
+
+In `Model/Config.php`, add a locale-to-language map constant and update `getSystemPrompt()`:
+
+Add this constant at the top of the class (after the existing XML_PATH constants):
+
+```php
+    private const LOCALE_LANGUAGE_MAP = [
+        'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
+        'ca' => 'Catalan', 'cs' => 'Czech', 'cy' => 'Welsh', 'da' => 'Danish',
+        'de' => 'German', 'el' => 'Greek', 'en' => 'English', 'es' => 'Spanish',
+        'et' => 'Estonian', 'fa' => 'Persian', 'fi' => 'Finnish', 'fr' => 'French',
+        'gl' => 'Galician', 'he' => 'Hebrew', 'hi' => 'Hindi', 'hr' => 'Croatian',
+        'hu' => 'Hungarian', 'id' => 'Indonesian', 'it' => 'Italian', 'ja' => 'Japanese',
+        'ka' => 'Georgian', 'ko' => 'Korean', 'lt' => 'Lithuanian', 'lv' => 'Latvian',
+        'mk' => 'Macedonian', 'ms' => 'Malay', 'nb' => 'Norwegian', 'nl' => 'Dutch',
+        'pl' => 'Polish', 'pt' => 'Portuguese', 'ro' => 'Romanian', 'ru' => 'Russian',
+        'sk' => 'Slovak', 'sl' => 'Slovenian', 'sq' => 'Albanian', 'sr' => 'Serbian',
+        'sv' => 'Swedish', 'th' => 'Thai', 'tr' => 'Turkish', 'uk' => 'Ukrainian',
+        'vi' => 'Vietnamese', 'zh' => 'Chinese',
+    ];
+```
+
+Replace the existing `getSystemPrompt()` method:
+
+```php
+    public function getSystemPrompt(): string
+    {
+        $basePrompt = (string)$this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        if ($locale) {
+            $langCode = substr($locale, 0, 2);
+            $language = self::LOCALE_LANGUAGE_MAP[$langCode] ?? null;
+            if ($language && $langCode !== 'en') {
+                $basePrompt = 'Respond in ' . $language . '. ' . $basePrompt;
+            }
+        }
+
+        return $basePrompt;
+    }
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "feat: locale-aware system prompt prepends language instruction (#12)"
+```
+
+---
+
+### Task 7: Create enrichment log DB schema
+
+**Files:**
+- Create: `etc/db_schema.xml`
+- Create: `etc/db_schema_whitelist.json`
+
+**Step 1: Create the declarative schema**
+
+Create file `etc/db_schema.xml`:
+
+```xml
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="mageos_catalogai_enrichment_log" resource="default" engine="innodb"
+           comment="AI Enrichment Status Log">
+        <column xsi:type="int" name="log_id" unsigned="true" nullable="false" identity="true"
+                comment="Log ID"/>
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false"
+                comment="Product Entity ID"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Attribute Code"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" default="0"
+                comment="Store ID"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="32" default="generated"
+                comment="Enrichment Status"/>
+        <column xsi:type="timestamp" name="generated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Generation Timestamp"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Last Updated"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="log_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE">
+            <column name="entity_id"/>
+            <column name="attribute_code"/>
+            <column name="store_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_STATUS" indexType="btree">
+            <column name="status"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID" indexType="btree">
+            <column name="entity_id"/>
+        </index>
+    </table>
+</schema>
+```
+
+**Step 2: Generate the whitelist**
+
+Run from Magento root (inside Warden):
+
+```bash
+warden env exec php-fpm bin/magento setup:db-declaration:generate-whitelist --module-name=MageOS_CatalogDataAI
+```
+
+This creates `etc/db_schema_whitelist.json`. If running outside Warden is not possible, create it manually:
+
+```json
+{
+    "mageos_catalogai_enrichment_log": {
+        "column": {
+            "log_id": true,
+            "entity_id": true,
+            "attribute_code": true,
+            "store_id": true,
+            "status": true,
+            "generated_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+        }
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add etc/db_schema.xml etc/db_schema_whitelist.json
+git commit -m "feat: add enrichment log DB table schema (#48)"
+```
+
+---
+
+### Task 8: Create EnrichmentLog model and resource model
+
+**Files:**
+- Create: `Model/EnrichmentLog.php`
+- Create: `Model/ResourceModel/EnrichmentLog.php`
+- Create: `Model/ResourceModel/EnrichmentLog/Collection.php`
+
+**Step 1: Create the resource model**
+
+Create file `Model/ResourceModel/EnrichmentLog.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class EnrichmentLog extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_enrichment_log', 'log_id');
+    }
+}
+```
+
+**Step 2: Create the model**
+
+Create file `Model/EnrichmentLog.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class EnrichmentLog extends AbstractModel
+{
+    public const STATUS_GENERATED = 'generated';
+    public const STATUS_PENDING_REVIEW = 'pending_review';
+    public const STATUS_MODIFIED = 'modified';
+
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLogResource::class);
+    }
+}
+```
+
+**Step 3: Create the collection**
+
+Create file `Model/ResourceModel/EnrichmentLog/Collection.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLog::class, EnrichmentLogResource::class);
+    }
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add Model/EnrichmentLog.php Model/ResourceModel/EnrichmentLog.php Model/ResourceModel/EnrichmentLog/Collection.php
+git commit -m "feat: add EnrichmentLog model, resource model, and collection (#48)"
+```
+
+---
+
+### Task 9: Create EnrichmentLogger service
+
+**Files:**
+- Create: `Model/Product/EnrichmentLogger.php`
+- Test: `Test/Unit/Model/Product/EnrichmentLoggerTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/EnrichmentLoggerTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class EnrichmentLoggerTest extends TestCase
+{
+    public function test_log_creates_new_entry_when_none_exists(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($this->createConfiguredMock(
+            EnrichmentLog::class,
+            ['getId' => null]
+        ));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $newLog = $this->createMock(EnrichmentLog::class);
+        $newLog->expects($this->once())->method('setData')->with($this->callback(
+            fn(array $data) => $data['entity_id'] === 42
+                && $data['attribute_code'] === 'description'
+                && $data['store_id'] === 1
+                && $data['status'] === EnrichmentLog::STATUS_GENERATED
+        ));
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $logFactory->method('create')->willReturn($newLog);
+
+        $resource = $this->createMock(EnrichmentLogResource::class);
+        $resource->expects($this->once())->method('save')->with($newLog);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $logger->log(42, 'description', 1);
+    }
+}
+```
+
+**Step 2: Create the service**
+
+Create file `Model/Product/EnrichmentLogger.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class EnrichmentLogger
+{
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogFactory $logFactory,
+        private readonly EnrichmentLogResource $resource
+    ) {
+    }
+
+    public function log(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId()) {
+            $existing->setData('status', EnrichmentLog::STATUS_GENERATED);
+            $this->resource->save($existing);
+        } else {
+            $log = $this->logFactory->create();
+            $log->setData([
+                'entity_id' => $entityId,
+                'attribute_code' => $attributeCode,
+                'store_id' => $storeId,
+                'status' => EnrichmentLog::STATUS_GENERATED,
+            ]);
+            $this->resource->save($log);
+        }
+    }
+
+    public function markModified(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId() && $existing->getData('status') !== EnrichmentLog::STATUS_MODIFIED) {
+            $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
+            $this->resource->save($existing);
+        }
+    }
+
+    public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        return $existing->getId() ? $existing->getData('status') : null;
+    }
+
+    public function getStatusesForProduct(int $entityId, int $storeId): array
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        $statuses = [];
+        foreach ($collection as $item) {
+            $statuses[$item->getData('attribute_code')] = $item->getData('status');
+        }
+
+        return $statuses;
+    }
+
+    private function find(int $entityId, string $attributeCode, int $storeId): EnrichmentLog
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getFirstItem();
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Product/EnrichmentLogger.php Test/Unit/Model/Product/EnrichmentLoggerTest.php
+git commit -m "feat: add EnrichmentLogger service for tracking AI-generated attributes (#48)"
+```
+
+---
+
+### Task 10: Wire EnrichmentLogger into Enricher
+
+**Files:**
+- Modify: `Model/Product/Enricher.php`
+
+**Step 1: Add EnrichmentLogger to Enricher constructor and log after enrichment**
+
+In `Model/Product/Enricher.php`:
+
+Add the import:
+```php
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+```
+
+Update the constructor to add the logger:
+```php
+    public function __construct(
+        private readonly Factory $clientFactory,
+        private readonly Config $config,
+        private readonly EnrichmentLogger $enrichmentLogger
+    ) {
+    }
+```
+
+In the `enrichAttribute` method, after the line `$product->setData($attributeCode, $result->message?->content);` (inside the `if($result = ...)` block), add:
+
+```php
+                $this->enrichmentLogger->log(
+                    (int)$product->getId(),
+                    $attributeCode,
+                    (int)$product->getStoreId()
+                );
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Enricher.php
+git commit -m "feat: Enricher logs enrichment status after successful AI generation (#48)"
+```
+
+---
+
+### Task 11: Detect manual edits in SaveBefore observer
+
+**Files:**
+- Modify: `Observer/Product/SaveBefore.php`
+
+**Step 1: Add manual edit detection**
+
+Replace `Observer/Product/SaveBefore.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Observer\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class SaveBefore implements ObserverInterface
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly Enricher $enricher,
+        private readonly EnrichmentLogger $enrichmentLogger
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        /** @var Product $product */
+        $product = $observer->getProduct();
+
+        if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
+            $this->enricher->execute($product);
+            return;
+        }
+
+        // Detect manual edits to enriched attributes on existing products
+        if (!$product->isObjectNew() && $product->getId()) {
+            $this->detectManualEdits($product);
+        }
+    }
+
+    private function detectManualEdits(Product $product): void
+    {
+        $storeId = (int)$product->getStoreId();
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            if (!$product->dataHasChangedFor($attributeCode)) {
+                continue;
+            }
+
+            $this->enrichmentLogger->markModified(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId
+            );
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Observer/Product/SaveBefore.php
+git commit -m "feat: detect manual edits to enriched attributes, mark as modified (#48)"
+```
+
+---
+
+### Task 12: Add enrichment status UI modifier for product edit form
+
+**Files:**
+- Create: `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php`
+- Modify: `etc/adminhtml/di.xml` (create if not exists)
+
+**Step 1: Create the UI modifier**
+
+Create file `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\Framework\Stdlib\ArrayManager;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class EnrichmentStatus extends AbstractModifier
+{
+    private const STATUS_LABELS = [
+        'generated' => 'AI Generated',
+        'pending_review' => 'Pending Review',
+        'modified' => 'AI Generated (Modified)',
+    ];
+
+    public function __construct(
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly Config $config,
+        private readonly ArrayManager $arrayManager
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            $containerPath = $this->arrayManager->findPath(
+                $attributeCode,
+                $meta,
+                null,
+                'children'
+            );
+
+            if ($containerPath) {
+                $meta = $this->arrayManager->merge(
+                    $containerPath . '/arguments/data/config',
+                    $meta,
+                    [
+                        'additionalClasses' => 'mageos-catalogai-enriched-field',
+                    ]
+                );
+            }
+        }
+
+        return $meta;
+    }
+}
+```
+
+**Step 2: Register the modifier in adminhtml di.xml**
+
+Create file `etc/adminhtml/di.xml`:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="mageos_catalogai_enrichment_status" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus</item>
+                    <item name="sortOrder" xsi:type="number">200</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>
+```
+
+**Step 3: Commit**
+
+```bash
+git add Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php etc/adminhtml/di.xml
+git commit -m "feat: add enrichment status UI modifier for product edit form (#48)"
+```
+
+---
+
+### Task 13: Update module.xml sequence
+
+**Files:**
+- Modify: `etc/module.xml`
+
+**Step 1: Add Magento_Store to the module sequence**
+
+The module now depends on store scope resolution. In `etc/module.xml`, add `Magento_Store` to the sequence:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="MageOS_CatalogDataAI">
+        <sequence>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
+</config>
+```
+
+**Step 2: Commit**
+
+```bash
+git add etc/module.xml
+git commit -m "feat: add Magento_Store to module sequence (#12)"
+```
+
+---
+
+### Task 14: Smoke test — setup:upgrade and di:compile
+
+**Step 1: Run Magento setup commands**
+
+From the Magento root (inside Warden):
+
+```bash
+warden env exec php-fpm bin/magento setup:upgrade
+warden env exec php-fpm bin/magento setup:di:compile
+```
+
+Both should complete without errors.
+
+**Step 2: Verify the DB table was created**
+
+```bash
+warden env exec php-fpm bin/magento db:query "DESCRIBE mageos_catalogai_enrichment_log"
+```
+
+Expected: table with columns `log_id`, `entity_id`, `attribute_code`, `store_id`, `status`, `generated_at`, `updated_at`.
+
+**Step 3: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+Expected: All tests pass.
+
+**Step 4: Final commit (if any adjustments)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 2"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| Modify | `Api/RequestInterface.php` |
+| Modify | `Model/Product/Request.php` |
+| Modify | `Model/Product/Publisher.php` |
+| Modify | `Model/Product/Consumer.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Modify | `Model/Config.php` |
+| Modify | `Observer/Product/SaveBefore.php` |
+| Modify | `Observer/Product/SaveAfter.php` |
+| Modify | `Controller/Adminhtml/Product/MassEnrich.php` |
+| Modify | `etc/module.xml` |
+| Modify | `Test/Unit/Model/ConfigTest.php` |
+| Create | `etc/db_schema.xml` |
+| Create | `etc/db_schema_whitelist.json` |
+| Create | `etc/adminhtml/di.xml` |
+| Create | `Model/EnrichmentLog.php` |
+| Create | `Model/ResourceModel/EnrichmentLog.php` |
+| Create | `Model/ResourceModel/EnrichmentLog/Collection.php` |
+| Create | `Model/Product/EnrichmentLogger.php` |
+| Create | `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php` |
+| Create | `Test/Unit/Model/Product/RequestTest.php` |
+| Create | `Test/Unit/Model/Product/EnrichmentLoggerTest.php` |

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="mageos_catalogai_enrichment_status" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus</item>
+                    <item name="sortOrder" xsi:type="number">200</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,27 +35,17 @@
                     <label>OpenAI API Max Tokens</label>
                 </field>
             </group>
-            <group id="product" translate="label" sortOrder="20" showInDefault="1" showInStore="1">
+            <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
                 <label>Product Fields Auto-Generation</label>
                 <comment>
-                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name}) as product attribute data placeholder
+                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name) as product attribute data placeholder.
                     <br />
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
-                <field id="short_description" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" canRestore="1">
-                    <label>Short Description</label>
-                </field>
-                <field id="description" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" canRestore="1">
-                    <label>Description</label>
-                </field>
-                <field id="meta_title" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" canRestore="1">
-                    <label>Meta Title</label>
-                </field>
-                <field id="meta_keyword" translate="label comment" type="textarea" sortOrder="50" showInDefault="1" canRestore="1">
-                    <label>Meta Keywords</label>
-                </field>
-                <field id="meta_description" translate="label comment" type="textarea" sortOrder="60" showInDefault="1" canRestore="1">
-                    <label>Meta Description</label>
+                <field id="attribute_prompts" translate="label" sortOrder="10" showInDefault="1" showInStore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\ProductAttributes</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                 </field>
             </group>
             <group id="advanced" translate="label" sortOrder="30" showInDefault="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,15 +62,19 @@
                 <label>Advanced Settings</label>
                 <field id="system_prompt" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
                     <label>System Prompt</label>
+                    <comment><![CDATA[Instructions sent to the AI model as the developer/system role. Defines the AI's behavior.]]></comment>
                 </field>
                 <field id="temperature" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
-                    <label>System Prompt</label>
+                    <label>Temperature</label>
+                    <comment><![CDATA[Controls randomness. 0.0 = deterministic, 1.0 = creative. Default: 0]]></comment>
                 </field>
                 <field id="frequency_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>Frequency Penalty</label>
+                    <comment><![CDATA[Reduces repetition of token sequences. Range: -2.0 to 2.0. Default: 0]]></comment>
                 </field>
-                <field id="presence_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
+                <field id="presence_penalty" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>Presence Penalty</label>
+                    <comment><![CDATA[Encourages new topics. Range: -2.0 to 2.0. Default: 0]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,8 +10,33 @@
                 <openai_max_tokens>1000</openai_max_tokens>
             </settings>
             <product>
-                <short_description>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</short_description>
-                <description>write a detailed product description for {{name}} with features in bullet list, under 1000 words</description>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute>short_description</attribute>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                        <enabled>1</enabled>
+                    </short_description>
+                    <description>
+                        <attribute>description</attribute>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                        <enabled>1</enabled>
+                    </description>
+                    <meta_title>
+                        <attribute>meta_title</attribute>
+                        <prompt>write a concise SEO meta title for {{name}}, under 60 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_title>
+                    <meta_keyword>
+                        <attribute>meta_keyword</attribute>
+                        <prompt>generate comma-separated SEO keywords for {{name}}, max 10 keywords</prompt>
+                        <enabled>1</enabled>
+                    </meta_keyword>
+                    <meta_description>
+                        <attribute>meta_description</attribute>
+                        <prompt>write an SEO meta description for {{name}}, under 160 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_description>
+                </attribute_prompts>
             </product>
             <advanced>
                 <system_prompt>Be a content generator, just reply with the content, skip all introductions.</system_prompt>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="mageos_catalogai_enrichment_log" resource="default" engine="innodb"
+           comment="AI Enrichment Status Log">
+        <column xsi:type="int" name="log_id" unsigned="true" nullable="false" identity="true"
+                comment="Log ID"/>
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false"
+                comment="Product Entity ID"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Attribute Code"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" default="0"
+                comment="Store ID"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="32" default="generated"
+                comment="Enrichment Status"/>
+        <column xsi:type="timestamp" name="generated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Generation Timestamp"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Last Updated"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="log_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE">
+            <column name="entity_id"/>
+            <column name="attribute_code"/>
+            <column name="store_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_STATUS" indexType="btree">
+            <column name="status"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID" indexType="btree">
+            <column name="entity_id"/>
+        </index>
+    </table>
+</schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,0 +1,21 @@
+{
+    "mageos_catalogai_enrichment_log": {
+        "column": {
+            "log_id": true,
+            "entity_id": true,
+            "attribute_code": true,
+            "store_id": true,
+            "status": true,
+            "generated_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+        }
+    }
+}

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="MageOS_CatalogDataAI">
         <sequence>
             <module name="Magento_Catalog"/>
+            <module name="Magento_Store"/>
         </sequence>
     </module>
 </config>

--- a/registration.php
+++ b/registration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 \Magento\Framework\Component\ComponentRegistrar::register(


### PR DESCRIPTION
## Summary

- **Fixes #12**: Store-scoped enrichment with locale-aware AI output — the module now respects store context and automatically instructs the AI to respond in the store's language
- **Fixes #48**: Tracks which product attributes were AI-generated with status indicators on the product edit form

**Depends on:** #52 (Phase 1: Housekeeping + Configurable Attributes)

## Multi-Store/Locale (#12) Details

The enrichment pipeline now carries store context end-to-end:

- `Request` DTO gained a `storeId` field (defaults to `0` for backward compatibility with in-flight queue messages)
- `Publisher` accepts and passes `storeId` to queue messages
- `Consumer` sets the correct store scope before loading the product and enriching
- `SaveAfter` observer passes the product's store ID to the publisher
- `MassEnrich` controller passes the current admin store scope to the publisher
- `Config::getSystemPrompt()` detects the store's locale (`general/locale/code`) and prepends "Respond in {Language}." to the system prompt for non-English locales (42 languages supported)

## Enrichment Status Flags (#48) Details

A new `mageos_catalogai_enrichment_log` DB table tracks enrichment status per product/attribute/store with a unique constraint on `(entity_id, attribute_code, store_id)`.

- `EnrichmentLog` model with status constants: `generated`, `pending_review`, `modified`
- `EnrichmentLogger` service provides `log()`, `markModified()`, `getStatus()`, and `getStatusesForProduct()`
- `Enricher` writes a log entry after each successful AI generation
- `SaveBefore` observer detects manual edits to previously enriched attributes and marks them as `modified`
- UI modifier adds a CSS class (`mageos-catalogai-enriched-field`) to enriched fields on the product edit form for future visual indicators

## Test plan

- [ ] Run `setup:upgrade` — should create the `mageos_catalogai_enrichment_log` table
- [ ] Run `setup:di:compile` — should complete without errors
- [ ] Verify enrichment still works on default store (backward compatible)
- [ ] Configure a non-English store (e.g., French locale), enrich a product — verify AI output is in the store's language
- [ ] Mass enrich products from the admin grid — verify store scope is passed
- [ ] After AI enrichment, check the `mageos_catalogai_enrichment_log` table for `generated` status entries
- [ ] Manually edit an AI-generated field and save — verify log status changes to `modified`
- [ ] Open product edit form — verify enriched fields have the `mageos-catalogai-enriched-field` CSS class