### PR TITLE
Phase 4: Review/Approval Workflow

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'single_quote' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    ])
+    ->setFinder($finder);

--- a/Api/Data/PromptRuleInterface.php
+++ b/Api/Data/PromptRuleInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api\Data;
+
+interface PromptRuleInterface
+{
+    public const RULE_ID = 'rule_id';
+    public const NAME = 'name';
+    public const ATTRIBUTE_CODE = 'attribute_code';
+    public const STORE_IDS = 'store_ids';
+    public const CONDITIONS_SERIALIZED = 'conditions_serialized';
+    public const PROMPT = 'prompt';
+    public const PRIORITY = 'priority';
+    public const IS_ACTIVE = 'is_active';
+
+    public function getRuleId(): ?int;
+    public function getName(): string;
+    public function getAttributeCode(): string;
+    public function getStoreIds(): string;
+    public function getConditionsSerialized(): ?string;
+    public function getPrompt(): string;
+    public function getPriority(): int;
+    public function getIsActive(): bool;
+}

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;
@@ -7,7 +6,7 @@ namespace MageOS\CatalogDataAI\Api;
 interface RequestInterface
 {
     /**
-     * Retrieve products id.
+     * Retrieve product id.
      * @return int
      */
     public function getId(): int;
@@ -17,4 +16,10 @@ interface RequestInterface
      * @return bool
      */
     public function getOverwrite(): bool;
+
+    /**
+     * Retrieve store id.
+     * @return int
+     */
+    public function getStoreId(): int;
 }

--- a/Block/Adminhtml/Form/Field/AttributeColumn.php
+++ b/Block/Adminhtml/Form/Field/AttributeColumn.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\View\Element\Context;
+use Magento\Framework\View\Element\Html\Select;
+
+class AttributeColumn extends Select
+{
+    private array $attributeOptions = [];
+
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
+        ?Context $context = null,
+        array $data = []
+    ) {
+        if ($context !== null) {
+            parent::__construct($context, $data);
+        }
+    }
+
+    public function getOptions(): array
+    {
+        if (empty($this->attributeOptions)) {
+            $searchCriteria = $this->searchCriteriaBuilder
+                ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+                ->create();
+
+            $attributes = $this->attributeRepository->getList($searchCriteria);
+
+            foreach ($attributes->getItems() as $attribute) {
+                $this->attributeOptions[$attribute->getAttributeCode()] = $attribute->getDefaultFrontendLabel()
+                    ?? $attribute->getAttributeCode();
+            }
+
+            asort($this->attributeOptions);
+        }
+
+        return $this->attributeOptions;
+    }
+
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            $this->setOptions($this->getOptions());
+        }
+
+        foreach ($this->getOptions() as $code => $label) {
+            $this->addOption($code, $label);
+        }
+
+        return parent::_toHtml();
+    }
+}

--- a/Block/Adminhtml/Form/Field/ProductAttributes.php
+++ b/Block/Adminhtml/Form/Field/ProductAttributes.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class ProductAttributes extends AbstractFieldArray
+{
+    private ?AttributeColumn $attributeRenderer = null;
+
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn('attribute', [
+            'label' => __('Attribute'),
+            'renderer' => $this->getAttributeRenderer(),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('prompt', [
+            'label' => __('Prompt'),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('enabled', [
+            'label' => __('Enabled'),
+            'class' => 'required-entry',
+        ]);
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Attribute');
+    }
+
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+        $attribute = $row->getData('attribute');
+
+        if ($attribute !== null) {
+            $key = 'option_' . $this->getAttributeRenderer()->calcOptionHash($attribute);
+            $options[$key] = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getAttributeRenderer(): AttributeColumn
+    {
+        if ($this->attributeRenderer === null) {
+            $this->attributeRenderer = $this->getLayout()->createBlock(
+                AttributeColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->attributeRenderer;
+    }
+}

--- a/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class DeleteButton implements ButtonProviderInterface
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly UrlInterface $urlBuilder
+    ) {
+    }
+
+    public function getButtonData(): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if (!$ruleId) {
+            return [];
+        }
+
+        return [
+            'label' => __('Delete Rule'),
+            'class' => 'delete',
+            'on_click' => sprintf(
+                "deleteConfirm('%s', '%s', {data: {}})",
+                __('Are you sure you want to delete this rule?'),
+                $this->urlBuilder->getUrl('*/*/delete', ['rule_id' => $ruleId])
+            ),
+            'sort_order' => 20,
+        ];
+    }
+}

--- a/Block/Adminhtml/PromptRule/Edit/SaveButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/SaveButton.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class SaveButton implements ButtonProviderInterface
+{
+    public function getButtonData(): array
+    {
+        return [
+            'label' => __('Save Rule'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+    }
+}

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
 
+use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Backend\App\Action;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
@@ -41,7 +42,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
-        if($this->config->isEnabled()) {
+        if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
@@ -54,8 +55,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
                     __('A total of %1 record(s) are scheduled to get data enriched.', $productEnriched)
                 );
             }
-        }
-        else {
+        } else {
             $this->messageManager->addErrorMessage(
                 __('Data enrichment is disabled. Please enable it in the configuration.')
             );

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Ui\Component\MassAction\Filter;
 use MageOS\CatalogDataAI\Model\Config;
+use Magento\Store\Model\StoreManagerInterface;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
 class MassEnrich extends Action implements HttpPostActionInterface
@@ -27,6 +28,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         private readonly Config                     $config,
         private readonly Publisher                  $publisher,
         private readonly ProductRepositoryInterface $productRepository,
+        private readonly StoreManagerInterface $storeManager,
     ) {
         parent::__construct($context);
     }
@@ -42,11 +44,12 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
+        $storeId = (int)$this->storeManager->getStore()->getId();
         if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
-                $this->publisher->execute($product->getId(), $this->overwrite);
+                $this->publisher->execute($product->getId(), $this->overwrite, $storeId);
                 $productEnriched++;
             }
 

--- a/Controller/Adminhtml/Product/MassEnrichSafe.php
+++ b/Controller/Adminhtml/Product/MassEnrichSafe.php
@@ -1,9 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
-
-use MageOS\CatalogDataAI\Controller\Adminhtml\Product\MassEnrich;
 
 class MassEnrichSafe extends MassEnrich
 {

--- a/Controller/Adminhtml/PromptRule/Delete.php
+++ b/Controller/Adminhtml/PromptRule/Delete.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Delete extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $redirect = $this->resultRedirectFactory->create()->setPath('*/*/');
+
+        if (!$ruleId) {
+            $this->messageManager->addErrorMessage(__('Rule ID is required.'));
+            return $redirect;
+        }
+
+        $rule = $this->ruleFactory->create();
+        $this->ruleResource->load($rule, $ruleId);
+
+        if (!$rule->getRuleId()) {
+            $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+            return $redirect;
+        }
+
+        try {
+            $this->ruleResource->delete($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been deleted.'));
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+        }
+
+        return $redirect;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Edit.php
+++ b/Controller/Adminhtml/PromptRule/Edit.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Edit extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $this->resultRedirectFactory->create()->setPath('*/*/');
+            }
+        }
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(
+            $ruleId ? __('Edit Rule: %1', $rule->getName()) : __('New Prompt Rule')
+        );
+
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Index.php
+++ b/Controller/Adminhtml/PromptRule/Index.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Prompt Rules'));
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/MassDelete.php
+++ b/Controller/Adminhtml/PromptRule/MassDelete.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class MassDelete extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $deleted = 0;
+
+        foreach ($collection as $rule) {
+            $this->ruleResource->delete($rule);
+            $deleted++;
+        }
+
+        $this->messageManager->addSuccessMessage(__('A total of %1 rule(s) have been deleted.', $deleted));
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}

--- a/Controller/Adminhtml/PromptRule/NewAction.php
+++ b/Controller/Adminhtml/PromptRule/NewAction.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+
+class NewAction extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function execute()
+    {
+        return $this->resultFactory->create(ResultFactory::TYPE_FORWARD)->forward('edit');
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Preview.php
+++ b/Controller/Adminhtml/PromptRule/Preview.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\JsonFactory;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+
+class Preview extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $jsonFactory,
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly Enricher $enricher
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $result = $this->jsonFactory->create();
+        $sku = $this->getRequest()->getParam('sku');
+        $prompt = $this->getRequest()->getParam('prompt');
+
+        if (!$sku || !$prompt) {
+            return $result->setData([
+                'success' => false,
+                'message' => 'SKU and prompt are required.',
+            ]);
+        }
+
+        try {
+            $product = $this->productRepository->get($sku);
+            $resolvedPrompt = $this->enricher->parsePrompt($prompt, $product);
+
+            return $result->setData([
+                'success' => true,
+                'resolved_prompt' => $resolvedPrompt,
+                'product_name' => $product->getName(),
+            ]);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => sprintf('Product with SKU "%s" not found.', $sku),
+            ]);
+        } catch (\Exception $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Save.php
+++ b/Controller/Adminhtml/PromptRule/Save.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Save extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $data = $this->getRequest()->getPostValue();
+        $redirect = $this->resultRedirectFactory->create();
+
+        if (!$data) {
+            return $redirect->setPath('*/*/');
+        }
+
+        $ruleId = (int)($data['rule_id'] ?? 0);
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $redirect->setPath('*/*/');
+            }
+        }
+
+        if (isset($data['store_ids']) && is_array($data['store_ids'])) {
+            $data['store_ids'] = implode(',', $data['store_ids']);
+        }
+
+        if (isset($data['rule']['conditions'])) {
+            $rule->loadPost(['conditions' => $data['rule']['conditions']]);
+        }
+
+        $rule->addData($data);
+
+        try {
+            $this->ruleResource->save($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been saved.'));
+
+            if ($this->getRequest()->getParam('back')) {
+                return $redirect->setPath('*/*/edit', ['rule_id' => $rule->getRuleId()]);
+            }
+            return $redirect->setPath('*/*/');
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+            return $redirect->setPath('*/*/edit', ['rule_id' => $ruleId]);
+        }
+    }
+}

--- a/Controller/Adminhtml/Review/Index.php
+++ b/Controller/Adminhtml/Review/Index.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::enrichment_review');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Enrichment Review'));
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/Review/MassApprove.php
+++ b/Controller/Adminhtml/Review/MassApprove.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class MassApprove extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly ProductRepositoryInterface $productRepository
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $approved = 0;
+
+        foreach ($collection as $logEntry) {
+            $log = $this->enrichmentLogger->approve((int)$logEntry->getId());
+            if ($log) {
+                $product = $this->productRepository->getById(
+                    (int)$log->getData('entity_id'),
+                    true,
+                    (int)$log->getData('store_id')
+                );
+                $product->setData($log->getData('attribute_code'), $log->getData('generated_content'));
+                $this->productRepository->save($product);
+                $approved++;
+            }
+        }
+
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 entry(ies) have been approved and published.', $approved)
+        );
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}

--- a/Controller/Adminhtml/Review/MassReject.php
+++ b/Controller/Adminhtml/Review/MassReject.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class MassReject extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly ProductRepositoryInterface $productRepository
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $rejected = 0;
+
+        foreach ($collection as $logEntry) {
+            $log = $this->enrichmentLogger->reject((int)$logEntry->getId());
+            if ($log && $log->getData('original_content') !== null) {
+                $product = $this->productRepository->getById(
+                    (int)$log->getData('entity_id'),
+                    true,
+                    (int)$log->getData('store_id')
+                );
+                $product->setData($log->getData('attribute_code'), $log->getData('original_content'));
+                $this->productRepository->save($product);
+            }
+            $rejected++;
+        }
+
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 entry(ies) have been rejected.', $rejected)
+        );
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -21,6 +21,21 @@ class Config
     public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'catalog_ai/advanced/frequency_penalty';
     public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'catalog_ai/advanced/presence_penalty';
 
+    private const LOCALE_LANGUAGE_MAP = [
+        'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
+        'ca' => 'Catalan', 'cs' => 'Czech', 'cy' => 'Welsh', 'da' => 'Danish',
+        'de' => 'German', 'el' => 'Greek', 'en' => 'English', 'es' => 'Spanish',
+        'et' => 'Estonian', 'fa' => 'Persian', 'fi' => 'Finnish', 'fr' => 'French',
+        'gl' => 'Galician', 'he' => 'Hebrew', 'hi' => 'Hindi', 'hr' => 'Croatian',
+        'hu' => 'Hungarian', 'id' => 'Indonesian', 'it' => 'Italian', 'ja' => 'Japanese',
+        'ka' => 'Georgian', 'ko' => 'Korean', 'lt' => 'Lithuanian', 'lv' => 'Latvian',
+        'mk' => 'Macedonian', 'ms' => 'Malay', 'nb' => 'Norwegian', 'nl' => 'Dutch',
+        'pl' => 'Polish', 'pt' => 'Portuguese', 'ro' => 'Romanian', 'ru' => 'Russian',
+        'sk' => 'Slovak', 'sl' => 'Slovenian', 'sq' => 'Albanian', 'sr' => 'Serbian',
+        'sv' => 'Swedish', 'th' => 'Thai', 'tr' => 'Turkish', 'uk' => 'Ukrainian',
+        'vi' => 'Vietnamese', 'zh' => 'Chinese',
+    ];
+
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig
     ) {
@@ -105,11 +120,27 @@ class Config
         return $this->isEnabled() && $this->getApiKey() && $product->isObjectNew();
     }
 
-    public function getSystemPrompt(): mixed
+    public function getSystemPrompt(): string
     {
-        return $this->scopeConfig->getValue(
-            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT
+        $basePrompt = (string)$this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
+
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        if ($locale) {
+            $langCode = substr($locale, 0, 2);
+            $language = self::LOCALE_LANGUAGE_MAP[$langCode] ?? null;
+            if ($language && $langCode !== 'en') {
+                $basePrompt = 'Respond in ' . $language . '. ' . $basePrompt;
+            }
+        }
+
+        return $basePrompt;
     }
 
     public function getTemperature(): float

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Config
 {
@@ -22,7 +23,8 @@ class Config
 
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig
-    ) {}
+    ) {
+    }
 
     public function isEnabled(): bool
     {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -9,17 +9,17 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Config
 {
-    public const XML_PATH_ENRICH_ENABLED = 'catalog_ai/settings/active';
-    public const XML_PATH_USE_ASYNC = 'catalog_ai/settings/async';
-    public const XML_PATH_OPENAI_ORGANIZATION_ID = 'catalog_ai/settings/openai_organization_id';
-    public const XML_PATH_OPENAI_API_KEY = 'catalog_ai/settings/openai_key';
-    public const XML_PATH_OPENAI_PROJECT_ID = 'catalog_ai/settings/openai_project_id';
-    public const XML_PATH_OPENAI_API_MODEL = 'catalog_ai/settings/openai_model';
-    public const XML_PATH_OPENAI_API_MAX_TOKENS = 'catalog_ai/settings/openai_max_tokens';
-    public const XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT = 'catalog_ai/advanced/system_prompt';
-    public const XML_PATH_OPENAI_API_ADVANCED_TEMPERATURE = 'catalog_ai/advanced/temperature';
-    public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'catalog_ai/advanced/frequency_penalty';
-    public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'catalog_ai/advanced/presence_penalty';
+    public const XML_PATH_ENRICH_ENABLED = 'ai_integration_enrichment/settings/active';
+    public const XML_PATH_USE_ASYNC = 'ai_integration_enrichment/settings/async';
+    public const XML_PATH_OPENAI_ORGANIZATION_ID = 'ai_integration_enrichment/settings/openai_organization_id';
+    public const XML_PATH_OPENAI_API_KEY = 'ai_integration_enrichment/settings/openai_key';
+    public const XML_PATH_OPENAI_PROJECT_ID = 'ai_integration_enrichment/settings/openai_project_id';
+    public const XML_PATH_OPENAI_API_MODEL = 'ai_integration_enrichment/settings/openai_model';
+    public const XML_PATH_OPENAI_API_MAX_TOKENS = 'ai_integration_enrichment/settings/openai_max_tokens';
+    public const XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT = 'ai_integration_enrichment/advanced/system_prompt';
+    public const XML_PATH_OPENAI_API_ADVANCED_TEMPERATURE = 'ai_integration_enrichment/advanced/temperature';
+    public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'ai_integration_enrichment/advanced/frequency_penalty';
+    public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'ai_integration_enrichment/advanced/presence_penalty';
 
     private const LOCALE_LANGUAGE_MAP = [
         'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
@@ -91,7 +91,7 @@ class Config
     public function getEnrichableAttributes(): array
     {
         $rows = $this->scopeConfig->getValue(
-            'catalog_ai/product/attribute_prompts'
+            'ai_integration_enrichment/product/attribute_prompts'
         );
 
         if (!is_array($rows)) {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -20,6 +20,7 @@ class Config
     public const XML_PATH_OPENAI_API_ADVANCED_TEMPERATURE = 'ai_integration_enrichment/advanced/temperature';
     public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'ai_integration_enrichment/advanced/frequency_penalty';
     public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'ai_integration_enrichment/advanced/presence_penalty';
+    public const XML_PATH_REQUIRE_REVIEW = 'ai_integration_enrichment/settings/require_review';
 
     private const LOCALE_LANGUAGE_MAP = [
         'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
@@ -51,6 +52,13 @@ class Config
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_USE_ASYNC
+        );
+    }
+
+    public function requiresReview(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_REQUIRE_REVIEW
         );
     }
 

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -73,12 +73,31 @@ class Config
         );
     }
 
-    public function getProductPrompt(string $attributeCode): mixed
+    public function getEnrichableAttributes(): array
     {
-        $path = 'catalog_ai/product/' . $attributeCode;
-        return $this->scopeConfig->getValue(
-            $path
+        $rows = $this->scopeConfig->getValue(
+            'catalog_ai/product/attribute_prompts'
         );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach ($rows as $row) {
+            if (isset($row['attribute'], $row['prompt'], $row['enabled']) && (int)$row['enabled'] === 1) {
+                $attributes[$row['attribute']] = $row['prompt'];
+            }
+        }
+
+        return $attributes;
+    }
+
+    public function getProductPrompt(string $attributeCode): ?string
+    {
+        $attributes = $this->getEnrichableAttributes();
+
+        return $attributes[$attributeCode] ?? null;
     }
 
     public function canEnrich(Product $product): bool

--- a/Model/Config/Source/EnrichableAttributes.php
+++ b/Model/Config/Source/EnrichableAttributes.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class EnrichableAttributes implements OptionSourceInterface
+{
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+    }
+
+    public function toOptionArray(): array
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+            ->create();
+
+        $attributes = $this->attributeRepository->getList($searchCriteria);
+
+        $options = [['value' => '', 'label' => __('-- Please Select --')]];
+        foreach ($attributes->getItems() as $attribute) {
+            $options[] = [
+                'value' => $attribute->getAttributeCode(),
+                'label' => ($attribute->getDefaultFrontendLabel() ?? $attribute->getAttributeCode()),
+            ];
+        }
+
+        usort($options, fn($a, $b) => strcmp((string)$a['label'], (string)$b['label']));
+
+        return $options;
+    }
+}

--- a/Model/Config/Source/EnrichmentStatus.php
+++ b/Model/Config/Source/EnrichmentStatus.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+
+class EnrichmentStatus implements OptionSourceInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => EnrichmentLog::STATUS_GENERATED, 'label' => __('Generated')],
+            ['value' => EnrichmentLog::STATUS_PENDING_REVIEW, 'label' => __('Pending Review')],
+            ['value' => EnrichmentLog::STATUS_MODIFIED, 'label' => __('Modified')],
+            ['value' => EnrichmentLog::STATUS_APPROVED, 'label' => __('Approved')],
+            ['value' => EnrichmentLog::STATUS_REJECTED, 'label' => __('Rejected')],
+        ];
+    }
+}

--- a/Model/Config/Source/OpenAIModel.php
+++ b/Model/Config/Source/OpenAIModel.php
@@ -2,11 +2,11 @@
 
 namespace MageOS\CatalogDataAI\Model\Config\Source;
 
+use Exception;
 use Magento\Framework\Data\OptionSourceInterface;
+use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
 use OpenAI;
 use OpenAI\Client as OpenAIClient;
-use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
-use Exception;
 
 class OpenAIModel implements OptionSourceInterface
 {

--- a/Model/EnrichmentLog.php
+++ b/Model/EnrichmentLog.php
@@ -11,6 +11,8 @@ class EnrichmentLog extends AbstractModel
     public const STATUS_GENERATED = 'generated';
     public const STATUS_PENDING_REVIEW = 'pending_review';
     public const STATUS_MODIFIED = 'modified';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
 
     protected function _construct(): void
     {

--- a/Model/EnrichmentLog.php
+++ b/Model/EnrichmentLog.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class EnrichmentLog extends AbstractModel
+{
+    public const STATUS_GENERATED = 'generated';
+    public const STATUS_PENDING_REVIEW = 'pending_review';
+    public const STATUS_MODIFIED = 'modified';
+
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLogResource::class);
+    }
+}

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -7,30 +6,25 @@ namespace MageOS\CatalogDataAI\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\Store\Model\StoreManagerInterface;
 
-/**
- * Class Consumer
- * @package Gaiterjones\RabbitMQ\MessageQueues\Product
- */
 class Consumer
 {
-    /**
-     * Consumer constructor.
-     */
     public function __construct(
-        private readonly Enricher          $enricher,
-        private readonly ProductRepository $productRepository,
+        private readonly Enricher              $enricher,
+        private readonly ProductRepository     $productRepository,
         private readonly StoreManagerInterface $storeManager
     ) {
     }
 
     public function execute(Request $request): void
     {
-        // @TODO: enrich for all stores if different value or language
-        $this->storeManager->setCurrentStore(0);
-        $product = $this->productRepository->getById($request->getId());
+        $this->storeManager->setCurrentStore($request->getStoreId());
+        $product = $this->productRepository->getById(
+            $request->getId(),
+            false,
+            $request->getStoreId()
+        );
         $product->setData('mageos_catalogai_overwrite', $request->getOverwrite());
         $this->enricher->execute($product);
         $this->productRepository->save($product);
     }
-
 }

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -19,7 +20,8 @@ class Consumer
         private readonly Enricher          $enricher,
         private readonly ProductRepository $productRepository,
         private readonly StoreManagerInterface $storeManager
-    ) {}
+    ) {
+    }
 
     public function execute(Request $request): void
     {

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product;
 use MageOS\CatalogDataAI\Model\Config;
 use OpenAI\Client;
 use OpenAI\Exceptions\ErrorException;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 use OpenAI\Factory;
 use OpenAI\Responses\Meta\MetaInformation;
 
@@ -17,7 +18,8 @@ class Enricher
 
     public function __construct(
         private readonly Factory $clientFactory,
-        private readonly Config $config
+        private readonly Config $config,
+        private readonly EnrichmentLogger $enrichmentLogger
     ) {
     }
 
@@ -79,6 +81,11 @@ class Enricher
             // @TODO:  no exception?
             if ($result = $response->choices[0]) {
                 $product->setData($attributeCode, $result->message?->content);
+                $this->enrichmentLogger->log(
+                    (int)$product->getId(),
+                    $attributeCode,
+                    (int)$product->getStoreId()
+                );
             }
             $this->backoff($response->meta());
         }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -56,10 +57,10 @@ class Enricher
 
     public function enrichAttribute(Product $product, string $attributeCode): void
     {
-        if(!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)){
+        if (!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)) {
             return;
         }
-        if($prompt = $this->config->getProductPrompt($attributeCode)) {
+        if ($prompt = $this->config->getProductPrompt($attributeCode)) {
 
             $prompt = $this->parsePrompt($prompt, $product);
 
@@ -82,7 +83,7 @@ class Enricher
             ]);
 
             // @TODO:  no exception?
-            if($result = $response->choices[0]) {
+            if ($result = $response->choices[0]) {
                 $product->setData($attributeCode, $result->message?->content);
             }
             $this->backoff($response->meta());
@@ -91,12 +92,12 @@ class Enricher
 
     public function backoff(MetaInformation $meta): void
     {
-        if($meta->requestLimit->remaining < 1) {
+        if ($meta->requestLimit->remaining < 1) {
             sleep($this->strToSeconds($meta->requestLimit->reset));
         }
         // 1 token ~= 0.75 word
         // do not use config value
-        if($meta->tokenLimit->remaining < 1000) {
+        if ($meta->tokenLimit->remaining < 1000) {
             sleep($this->strToSeconds($meta->tokenLimit->reset));
         }
     }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -6,6 +6,7 @@ namespace MageOS\CatalogDataAI\Model\Product;
 
 use Magento\Catalog\Model\Product;
 use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
 use OpenAI\Client;
 use OpenAI\Exceptions\ErrorException;
 use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
@@ -60,36 +61,59 @@ class Enricher
         }
         if ($prompt = $this->promptResolver->resolve($attributeCode, $product)) {
 
-            $prompt = $this->parsePrompt($prompt, $product);
+            $resolvedPrompt = $this->parsePrompt($prompt, $product);
+            $promptHash = hash('sha256', $resolvedPrompt);
+            $storeId = (int)$product->getStoreId();
+            $originalContent = (string)$product->getData($attributeCode);
 
-            $response = $this->getClient()->chat()->create([
-                'model' => $this->config->getApiModel(),
-                'temperature' => $this->config->getTemperature(),
-                'frequency_penalty' => $this->config->getFrequencyPenalty(),
-                'presence_penalty' => $this->config->getPresencePenalty(),
-                'max_completion_tokens' => $this->config->getApiMaxTokens(),
-                'messages' => [
-                    [
-                        'role' => 'developer',
-                        'content' => $this->config->getSystemPrompt()
-                    ],
-                    [
-                        'role' => 'user',
-                        'content' => $this->parsePrompt($prompt, $product)
+            // Check for cached response with same prompt hash
+            $cachedContent = $this->enrichmentLogger->findByPromptHash($promptHash, $attributeCode, $storeId);
+
+            if ($cachedContent !== null) {
+                $generatedContent = $cachedContent;
+            } else {
+                $response = $this->getClient()->chat()->create([
+                    'model' => $this->config->getApiModel(),
+                    'temperature' => $this->config->getTemperature(),
+                    'frequency_penalty' => $this->config->getFrequencyPenalty(),
+                    'presence_penalty' => $this->config->getPresencePenalty(),
+                    'max_completion_tokens' => $this->config->getApiMaxTokens(),
+                    'messages' => [
+                        [
+                            'role' => 'developer',
+                            'content' => $this->config->getSystemPrompt()
+                        ],
+                        [
+                            'role' => 'user',
+                            'content' => $resolvedPrompt
+                        ]
                     ]
-                ]
-            ]);
+                ]);
 
-            // @TODO:  no exception?
-            if ($result = $response->choices[0]) {
-                $product->setData($attributeCode, $result->message?->content);
-                $this->enrichmentLogger->log(
-                    (int)$product->getId(),
-                    $attributeCode,
-                    (int)$product->getStoreId()
-                );
+                if (!$result = $response->choices[0]) {
+                    return;
+                }
+                $generatedContent = $result->message?->content ?? '';
+                $this->backoff($response->meta());
             }
-            $this->backoff($response->meta());
+
+            $status = $this->config->requiresReview()
+                ? EnrichmentLog::STATUS_PENDING_REVIEW
+                : EnrichmentLog::STATUS_GENERATED;
+
+            if (!$this->config->requiresReview()) {
+                $product->setData($attributeCode, $generatedContent);
+            }
+
+            $this->enrichmentLogger->log(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId,
+                $generatedContent,
+                $originalContent,
+                $promptHash,
+                $status
+            );
         }
     }
 

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -9,6 +9,7 @@ use MageOS\CatalogDataAI\Model\Config;
 use OpenAI\Client;
 use OpenAI\Exceptions\ErrorException;
 use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
 use OpenAI\Factory;
 use OpenAI\Responses\Meta\MetaInformation;
 
@@ -19,7 +20,8 @@ class Enricher
     public function __construct(
         private readonly Factory $clientFactory,
         private readonly Config $config,
-        private readonly EnrichmentLogger $enrichmentLogger
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly PromptResolver $promptResolver
     ) {
     }
 
@@ -56,7 +58,7 @@ class Enricher
         if (!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)) {
             return;
         }
-        if ($prompt = $this->config->getProductPrompt($attributeCode)) {
+        if ($prompt = $this->promptResolver->resolve($attributeCode, $product)) {
 
             $prompt = $this->parsePrompt($prompt, $product);
 

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -36,13 +36,7 @@ class Enricher
 
     public function getAttributes(): array
     {
-        return [
-            'short_description',
-            'description',
-            'meta_title',
-            'meta_keyword',
-            'meta_description',
-        ];
+        return array_keys($this->config->getEnrichableAttributes());
     }
 
     /**

--- a/Model/Product/EnrichmentLogger.php
+++ b/Model/Product/EnrichmentLogger.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class EnrichmentLogger
+{
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogFactory $logFactory,
+        private readonly EnrichmentLogResource $resource
+    ) {
+    }
+
+    public function log(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId()) {
+            $existing->setData('status', EnrichmentLog::STATUS_GENERATED);
+            $this->resource->save($existing);
+        } else {
+            $log = $this->logFactory->create();
+            $log->setData([
+                'entity_id' => $entityId,
+                'attribute_code' => $attributeCode,
+                'store_id' => $storeId,
+                'status' => EnrichmentLog::STATUS_GENERATED,
+            ]);
+            $this->resource->save($log);
+        }
+    }
+
+    public function markModified(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId() && $existing->getData('status') !== EnrichmentLog::STATUS_MODIFIED) {
+            $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
+            $this->resource->save($existing);
+        }
+    }
+
+    public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        return $existing->getId() ? $existing->getData('status') : null;
+    }
+
+    public function getStatusesForProduct(int $entityId, int $storeId): array
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        $statuses = [];
+        foreach ($collection as $item) {
+            $statuses[$item->getData('attribute_code')] = $item->getData('status');
+        }
+
+        return $statuses;
+    }
+
+    private function find(int $entityId, string $attributeCode, int $storeId): EnrichmentLog
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getFirstItem();
+    }
+}

--- a/Model/Product/EnrichmentLogger.php
+++ b/Model/Product/EnrichmentLogger.php
@@ -17,12 +17,22 @@ class EnrichmentLogger
     ) {
     }
 
-    public function log(int $entityId, string $attributeCode, int $storeId): void
-    {
+    public function log(
+        int $entityId,
+        string $attributeCode,
+        int $storeId,
+        string $generatedContent = '',
+        string $originalContent = '',
+        string $promptHash = '',
+        string $status = EnrichmentLog::STATUS_GENERATED
+    ): void {
         $existing = $this->find($entityId, $attributeCode, $storeId);
 
         if ($existing->getId()) {
-            $existing->setData('status', EnrichmentLog::STATUS_GENERATED);
+            $existing->setData('status', $status);
+            $existing->setData('generated_content', $generatedContent);
+            $existing->setData('original_content', $originalContent);
+            $existing->setData('prompt_hash', $promptHash);
             $this->resource->save($existing);
         } else {
             $log = $this->logFactory->create();
@@ -30,7 +40,10 @@ class EnrichmentLogger
                 'entity_id' => $entityId,
                 'attribute_code' => $attributeCode,
                 'store_id' => $storeId,
-                'status' => EnrichmentLog::STATUS_GENERATED,
+                'status' => $status,
+                'generated_content' => $generatedContent,
+                'original_content' => $originalContent,
+                'prompt_hash' => $promptHash,
             ]);
             $this->resource->save($log);
         }
@@ -44,6 +57,48 @@ class EnrichmentLogger
             $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
             $this->resource->save($existing);
         }
+    }
+
+    public function approve(int $logId): ?EnrichmentLog
+    {
+        $log = $this->logFactory->create();
+        $this->resource->load($log, $logId);
+
+        if ($log->getId()) {
+            $log->setData('status', EnrichmentLog::STATUS_APPROVED);
+            $this->resource->save($log);
+            return $log;
+        }
+
+        return null;
+    }
+
+    public function reject(int $logId): ?EnrichmentLog
+    {
+        $log = $this->logFactory->create();
+        $this->resource->load($log, $logId);
+
+        if ($log->getId()) {
+            $log->setData('status', EnrichmentLog::STATUS_REJECTED);
+            $this->resource->save($log);
+            return $log;
+        }
+
+        return null;
+    }
+
+    public function findByPromptHash(string $promptHash, string $attributeCode, int $storeId): ?string
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('prompt_hash', $promptHash);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+        $collection->addFieldToFilter('generated_content', ['notnull' => true]);
+        $collection->setPageSize(1);
+
+        $item = $collection->getFirstItem();
+
+        return $item->getId() ? $item->getData('generated_content') : null;
     }
 
     public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string

--- a/Model/Product/PromptResolver.php
+++ b/Model/Product/PromptResolver.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Model\Product;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class PromptResolver
+{
+    public function __construct(
+        private readonly CollectionFactory $ruleCollectionFactory,
+        private readonly Config $config
+    ) {
+    }
+
+    public function resolve(string $attributeCode, Product $product): ?string
+    {
+        $storeId = (int)$product->getStoreId();
+
+        $collection = $this->ruleCollectionFactory->create();
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('is_active', 1);
+        $collection->setOrder('priority', 'DESC');
+
+        /** @var PromptRule $rule */
+        foreach ($collection as $rule) {
+            if ($rule->matchesStore($storeId) && $rule->matchesProduct($product)) {
+                return $rule->getPrompt();
+            }
+        }
+
+        return $this->config->getProductPrompt($attributeCode);
+    }
+}

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -19,15 +19,12 @@ class Publisher
     ) {
     }
 
-    /**
-     * @param int|string $productId
-     * @param bool $overwrite
-     */
-    public function execute(int|string $productId, bool $overwrite = false): void
+    public function execute(int|string $productId, bool $overwrite = false, int $storeId = 0): void
     {
         $request = $this->requestFactory->create([
             'id' => (int)$productId,
-            'overwrite' => $overwrite
+            'overwrite' => $overwrite,
+            'storeId' => $storeId,
         ]);
         $this->publisher->publish(self::TOPIC_NAME, $request);
     }

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -1,14 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
 
 use Magento\Framework\MessageQueue\PublisherInterface;
-use MageOS\CatalogDataAI\Model\Product\RequestFactory;
 
 class Publisher
 {
-    const TOPIC_NAME = 'mageos.product.enrich';
+    public const TOPIC_NAME = 'mageos.product.enrich';
 
     /**
      * Publisher constructor.
@@ -16,7 +16,8 @@ class Publisher
     public function __construct(
         private readonly PublisherInterface $publisher,
         private readonly RequestFactory     $requestFactory,
-    ) {}
+    ) {
+    }
 
     /**
      * @param int|string $productId

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -13,23 +12,23 @@ class Request implements RequestInterface
 {
     public function __construct(
         private readonly int $id,
-        private readonly bool $overwrite
+        private readonly bool $overwrite,
+        private readonly int $storeId = 0
     ) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOverwrite(): bool
     {
         return $this->overwrite;
+    }
+
+    public function getStoreId(): int
+    {
+        return $this->storeId;
     }
 }

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/PromptRule.php
+++ b/Model/PromptRule.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\CatalogRule\Model\Rule\Condition\Combine;
+use Magento\Rule\Model\AbstractModel;
+use MageOS\CatalogDataAI\Api\Data\PromptRuleInterface;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class PromptRule extends AbstractModel implements PromptRuleInterface
+{
+    protected $_eventPrefix = 'mageos_catalogai_prompt_rule';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRuleResource::class);
+    }
+
+    public function getConditionsInstance(): \Magento\Rule\Model\Condition\Combine
+    {
+        return $this->_conditionFactory->create(Combine::class);
+    }
+
+    public function getActionsInstance(): \Magento\Rule\Model\Action\Collection
+    {
+        return $this->_actionFactory->create(\Magento\Rule\Model\Action\Collection::class);
+    }
+
+    public function getRuleId(): ?int
+    {
+        return $this->getData(self::RULE_ID) ? (int)$this->getData(self::RULE_ID) : null;
+    }
+
+    public function getName(): string
+    {
+        return (string)$this->getData(self::NAME);
+    }
+
+    public function getAttributeCode(): string
+    {
+        return (string)$this->getData(self::ATTRIBUTE_CODE);
+    }
+
+    public function getStoreIds(): string
+    {
+        return (string)$this->getData(self::STORE_IDS);
+    }
+
+    public function getConditionsSerialized(): ?string
+    {
+        return $this->getData(self::CONDITIONS_SERIALIZED);
+    }
+
+    public function getPrompt(): string
+    {
+        return (string)$this->getData(self::PROMPT);
+    }
+
+    public function getPriority(): int
+    {
+        return (int)$this->getData(self::PRIORITY);
+    }
+
+    public function getIsActive(): bool
+    {
+        return (bool)$this->getData(self::IS_ACTIVE);
+    }
+
+    public function matchesProduct(\Magento\Catalog\Model\Product $product): bool
+    {
+        return $this->getConditions()->validate($product);
+    }
+
+    public function matchesStore(int $storeId): bool
+    {
+        $storeIds = $this->getStoreIds();
+        if ($storeIds === '' || $storeIds === '0') {
+            return true;
+        }
+        $ids = array_map('intval', explode(',', $storeIds));
+        return in_array(0, $ids, true) || in_array($storeId, $ids, true);
+    }
+}

--- a/Model/PromptRule/DataProvider.php
+++ b/Model/PromptRule/DataProvider.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\PromptRule;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\AbstractDataProvider;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class DataProvider extends AbstractDataProvider
+{
+    private array $loadedData = [];
+
+    public function __construct(
+        string $name,
+        string $primaryFieldName,
+        string $requestFieldName,
+        CollectionFactory $collectionFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $collectionFactory->create();
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    public function getData(): array
+    {
+        if (!empty($this->loadedData)) {
+            return $this->loadedData;
+        }
+
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            if ($rule->getRuleId()) {
+                $data = $rule->getData();
+                if (isset($data['store_ids']) && is_string($data['store_ids'])) {
+                    $data['store_ids'] = explode(',', $data['store_ids']);
+                }
+                $this->loadedData[$ruleId] = $data;
+            }
+        }
+
+        return $this->loadedData;
+    }
+}

--- a/Model/ResourceModel/EnrichmentLog.php
+++ b/Model/ResourceModel/EnrichmentLog.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class EnrichmentLog extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_enrichment_log', 'log_id');
+    }
+}

--- a/Model/ResourceModel/EnrichmentLog/Collection.php
+++ b/Model/ResourceModel/EnrichmentLog/Collection.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLog::class, EnrichmentLogResource::class);
+    }
+}

--- a/Model/ResourceModel/EnrichmentLog/Grid/Collection.php
+++ b/Model/ResourceModel/EnrichmentLog/Grid/Collection.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_enrichment_log',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('log_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}

--- a/Model/ResourceModel/PromptRule.php
+++ b/Model/ResourceModel/PromptRule.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class PromptRule extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_prompt_rule', 'rule_id');
+    }
+}

--- a/Model/ResourceModel/PromptRule/Collection.php
+++ b/Model/ResourceModel/PromptRule/Collection.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Collection extends AbstractCollection
+{
+    protected $_idFieldName = 'rule_id';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRule::class, PromptRuleResource::class);
+    }
+}

--- a/Model/ResourceModel/PromptRule/Grid/Collection.php
+++ b/Model/ResourceModel/PromptRule/Grid/Collection.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_prompt_rule',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\PromptRule::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('rule_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -24,7 +24,11 @@ class SaveAfter implements ObserverInterface
         $product = $observer->getProduct();
 
         if ($this->config->canEnrich($product) && $this->config->isAsync()) {
-            $this->publisher->execute($product->getId(), false);
+            $this->publisher->execute(
+                $product->getId(),
+                false,
+                (int)$product->getStoreId()
+            );
         }
     }
 }

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
@@ -14,14 +15,15 @@ class SaveAfter implements ObserverInterface
     public function __construct(
         private readonly Config $config,
         private readonly Publisher $publisher
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
         /** @var Product $product */
         $product = $observer->getProduct();
 
-        if($this->config->canEnrich($product) && $this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && $this->config->isAsync()) {
             $this->publisher->execute($product->getId(), false);
         }
     }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 
@@ -14,14 +15,15 @@ class SaveBefore implements ObserverInterface
     public function __construct(
         private readonly Config $config,
         private readonly Enricher $enricher
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
         /** @var Product $product */
         $product = $observer->getProduct();
 
-        if($this->config->canEnrich($product) && !$this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
             $this->enricher->execute($product);
         }
     }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
@@ -9,12 +8,14 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 
 class SaveBefore implements ObserverInterface
 {
     public function __construct(
         private readonly Config $config,
-        private readonly Enricher $enricher
+        private readonly Enricher $enricher,
+        private readonly EnrichmentLogger $enrichmentLogger
     ) {
     }
 
@@ -25,6 +26,29 @@ class SaveBefore implements ObserverInterface
 
         if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
             $this->enricher->execute($product);
+            return;
+        }
+
+        if (!$product->isObjectNew() && $product->getId()) {
+            $this->detectManualEdits($product);
+        }
+    }
+
+    private function detectManualEdits(Product $product): void
+    {
+        $storeId = (int)$product->getStoreId();
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            if (!$product->dataHasChangedFor($attributeCode)) {
+                continue;
+            }
+
+            $this->enrichmentLogger->markModified(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId
+            );
         }
     }
 }

--- a/Setup/Patch/Data/MigrateConfigToAiIntegration.php
+++ b/Setup/Patch/Data/MigrateConfigToAiIntegration.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class MigrateConfigToAiIntegration implements DataPatchInterface
+{
+    private const PATH_MAP = [
+        'catalog_ai/settings/active' => 'ai_integration_enrichment/settings/active',
+        'catalog_ai/settings/async' => 'ai_integration_enrichment/settings/async',
+        'catalog_ai/settings/openai_organization_id' => 'ai_integration_enrichment/settings/openai_organization_id',
+        'catalog_ai/settings/openai_key' => 'ai_integration_enrichment/settings/openai_key',
+        'catalog_ai/settings/openai_project_id' => 'ai_integration_enrichment/settings/openai_project_id',
+        'catalog_ai/settings/openai_model' => 'ai_integration_enrichment/settings/openai_model',
+        'catalog_ai/settings/openai_max_tokens' => 'ai_integration_enrichment/settings/openai_max_tokens',
+        'catalog_ai/product/attribute_prompts' => 'ai_integration_enrichment/product/attribute_prompts',
+        'catalog_ai/advanced/system_prompt' => 'ai_integration_enrichment/advanced/system_prompt',
+        'catalog_ai/advanced/temperature' => 'ai_integration_enrichment/advanced/temperature',
+        'catalog_ai/advanced/frequency_penalty' => 'ai_integration_enrichment/advanced/frequency_penalty',
+        'catalog_ai/advanced/presence_penalty' => 'ai_integration_enrichment/advanced/presence_penalty',
+    ];
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter
+    ) {
+    }
+
+    public function apply(): self
+    {
+        foreach (self::PATH_MAP as $oldPath => $newPath) {
+            $value = $this->scopeConfig->getValue($oldPath);
+            if ($value !== null) {
+                $this->configWriter->save($newPath, $value);
+                $this->configWriter->delete($oldPath);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [MigrateProductPromptsToDynamicRows::class];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
+++ b/Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class MigrateProductPromptsToDynamicRows implements DataPatchInterface
+{
+    private const OLD_ATTRIBUTE_PATHS = [
+        'short_description',
+        'description',
+        'meta_title',
+        'meta_keyword',
+        'meta_description',
+    ];
+
+    private const NEW_PATH = 'catalog_ai/product/attribute_prompts';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter,
+        private readonly Json $json
+    ) {
+    }
+
+    public function apply(): self
+    {
+        $rows = [];
+        $hasExistingConfig = false;
+
+        foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+            $oldPath = 'catalog_ai/product/' . $attributeCode;
+            $value = $this->scopeConfig->getValue($oldPath);
+
+            if ($value !== null && $value !== '') {
+                $hasExistingConfig = true;
+                $rows[$attributeCode] = [
+                    'attribute' => $attributeCode,
+                    'prompt' => $value,
+                    'enabled' => '1',
+                ];
+            }
+        }
+
+        if ($hasExistingConfig) {
+            $this->configWriter->save(self::NEW_PATH, $this->json->serialize($rows));
+
+            // Clean up old paths
+            foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+                $this->configWriter->delete('catalog_ai/product/' . $attributeCode);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+++ b/Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Block\Adminhtml\Form\Field;
+
+use MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributeColumn;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchResultsInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeColumnTest extends TestCase
+{
+    public function test_get_options_returns_text_and_textarea_attributes(): void
+    {
+        $attribute1 = $this->createMock(ProductAttributeInterface::class);
+        $attribute1->method('getAttributeCode')->willReturn('description');
+        $attribute1->method('getDefaultFrontendLabel')->willReturn('Description');
+
+        $attribute2 = $this->createMock(ProductAttributeInterface::class);
+        $attribute2->method('getAttributeCode')->willReturn('short_description');
+        $attribute2->method('getDefaultFrontendLabel')->willReturn('Short Description');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$attribute1, $attribute2]);
+
+        $searchCriteria = $this->createMock(SearchCriteria::class);
+
+        $searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $attributeRepository = $this->createMock(ProductAttributeRepositoryInterface::class);
+        $attributeRepository->method('getList')->willReturn($searchResults);
+
+        $column = new AttributeColumn($attributeRepository, $searchCriteriaBuilder);
+        $options = $column->getOptions();
+
+        $this->assertArrayHasKey('description', $options);
+        $this->assertArrayHasKey('short_description', $options);
+        $this->assertEquals('Description', $options['description']);
+        $this->assertEquals('Short Description', $options['short_description']);
+    }
+}

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -29,7 +29,7 @@ final class ConfigTest extends TestCase
 
         $this->scopeConfig->method('getValue')
             ->willReturnMap([
-                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+                ['ai_integration_enrichment/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
             ]);
 
         $result = $this->config->getEnrichableAttributes();
@@ -44,7 +44,7 @@ final class ConfigTest extends TestCase
     {
         $this->scopeConfig->method('getValue')
             ->willReturnMap([
-                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
+                ['ai_integration_enrichment/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
             ]);
 
         $result = $this->config->getEnrichableAttributes();
@@ -61,7 +61,7 @@ final class ConfigTest extends TestCase
 
         $this->scopeConfig->method('getValue')
             ->willReturnMap([
-                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+                ['ai_integration_enrichment/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
             ]);
 
         $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model;
 
 use MageOS\CatalogDataAI\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
@@ -27,8 +28,9 @@ final class ConfigTest extends TestCase
         ];
 
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn($serializedData);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
 
         $result = $this->config->getEnrichableAttributes();
 
@@ -36,15 +38,14 @@ final class ConfigTest extends TestCase
         $this->assertArrayHasKey('description', $result);
         $this->assertArrayHasKey('short_description', $result);
         $this->assertArrayNotHasKey('meta_title', $result);
-        $this->assertEquals('describe {{name}}', $result['description']);
-        $this->assertEquals('short desc for {{name}}', $result['short_description']);
     }
 
     public function test_get_enrichable_attributes_returns_empty_when_null(): void
     {
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn(null);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
 
         $result = $this->config->getEnrichableAttributes();
 
@@ -59,10 +60,38 @@ final class ConfigTest extends TestCase
         ];
 
         $this->scopeConfig->method('getValue')
-            ->with('catalog_ai/product/attribute_prompts')
-            ->willReturn($serializedData);
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
 
         $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
         $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+
+    public function test_get_system_prompt_includes_locale_language(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'fr_FR'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertStringContainsString('Respond in French', $result);
+        $this->assertStringContainsString('Be a content generator.', $result);
+    }
+
+    public function test_get_system_prompt_skips_locale_for_english(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'en_US'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertEquals('Be a content generator.', $result);
     }
 }

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model;
+
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    private ScopeConfigInterface $scopeConfig;
+    private Config $config;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->config = new Config($this->scopeConfig);
+    }
+
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+        $this->assertEquals('describe {{name}}', $result['description']);
+        $this->assertEquals('short desc for {{name}}', $result['short_description']);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn(null);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+}

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -5,6 +5,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
 
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
 use Magento\Catalog\Model\Product;
 use OpenAI\Factory;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +21,8 @@ final class EnricherTest extends TestCase
         ]);
 
         $factory = $this->createMock(Factory::class);
-        $enricher = new Enricher($factory, $config);
+        $logger = $this->createMock(EnrichmentLogger::class);
+        $enricher = new Enricher($factory, $config, $logger);
 
         $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
     }
@@ -29,7 +31,8 @@ final class EnricherTest extends TestCase
     {
         $config = $this->createMock(Config::class);
         $factory = $this->createMock(Factory::class);
-        $enricher = new Enricher($factory, $config);
+        $logger = $this->createMock(EnrichmentLogger::class);
+        $enricher = new Enricher($factory, $config, $logger);
 
         $product = $this->createMock(Product::class);
         $product->method('getData')

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use Magento\Catalog\Model\Product;
+use OpenAI\Factory;
+use PHPUnit\Framework\TestCase;
+
+final class EnricherTest extends TestCase
+{
+    public function test_get_attributes_returns_enabled_attribute_codes_from_config(): void
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('getEnrichableAttributes')->willReturn([
+            'description' => 'describe {{name}}',
+            'custom_field' => 'generate {{name}} custom',
+        ]);
+
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
+    }
+
+    public function test_parse_prompt_replaces_placeholders_with_product_data(): void
+    {
+        $config = $this->createMock(Config::class);
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $product = $this->createMock(Product::class);
+        $product->method('getData')
+            ->willReturnMap([
+                ['name', null, 'Cool Widget'],
+                ['price', null, '29.99'],
+            ]);
+
+        $result = $enricher->parsePrompt('describe {{name}} at {{price}}', $product);
+
+        $this->assertEquals('describe Cool Widget at 29.99', $result);
+    }
+}

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -6,6 +6,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
 use Magento\Catalog\Model\Product;
 use OpenAI\Factory;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,8 @@ final class EnricherTest extends TestCase
 
         $factory = $this->createMock(Factory::class);
         $logger = $this->createMock(EnrichmentLogger::class);
-        $enricher = new Enricher($factory, $config, $logger);
+        $promptResolver = $this->createMock(PromptResolver::class);
+        $enricher = new Enricher($factory, $config, $logger, $promptResolver);
 
         $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
     }
@@ -32,7 +34,8 @@ final class EnricherTest extends TestCase
         $config = $this->createMock(Config::class);
         $factory = $this->createMock(Factory::class);
         $logger = $this->createMock(EnrichmentLogger::class);
-        $enricher = new Enricher($factory, $config, $logger);
+        $promptResolver = $this->createMock(PromptResolver::class);
+        $enricher = new Enricher($factory, $config, $logger, $promptResolver);
 
         $product = $this->createMock(Product::class);
         $product->method('getData')

--- a/Test/Unit/Model/Product/EnrichmentLoggerTest.php
+++ b/Test/Unit/Model/Product/EnrichmentLoggerTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 final class EnrichmentLoggerTest extends TestCase
 {
-    public function test_log_creates_new_entry_when_none_exists(): void
+    public function test_log_creates_new_entry_with_content_and_hash(): void
     {
         $collection = $this->createMock(Collection::class);
         $collection->method('addFieldToFilter')->willReturnSelf();
@@ -31,6 +31,9 @@ final class EnrichmentLoggerTest extends TestCase
                 && $data['attribute_code'] === 'description'
                 && $data['store_id'] === 1
                 && $data['status'] === EnrichmentLog::STATUS_GENERATED
+                && $data['generated_content'] === 'AI output'
+                && $data['original_content'] === 'old value'
+                && $data['prompt_hash'] === 'abc123'
         ));
 
         $logFactory = $this->createMock(EnrichmentLogFactory::class);
@@ -40,6 +43,29 @@ final class EnrichmentLoggerTest extends TestCase
         $resource->expects($this->once())->method('save')->with($newLog);
 
         $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
-        $logger->log(42, 'description', 1);
+        $logger->log(42, 'description', 1, 'AI output', 'old value', 'abc123');
+    }
+
+    public function test_find_by_prompt_hash_returns_cached_content(): void
+    {
+        $item = $this->createMock(EnrichmentLog::class);
+        $item->method('getId')->willReturn(1);
+        $item->method('getData')->with('generated_content')->willReturn('cached response');
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setPageSize')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($item);
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $resource = $this->createMock(EnrichmentLogResource::class);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $result = $logger->findByPromptHash('hash123', 'description', 1);
+
+        $this->assertEquals('cached response', $result);
     }
 }

--- a/Test/Unit/Model/Product/EnrichmentLoggerTest.php
+++ b/Test/Unit/Model/Product/EnrichmentLoggerTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class EnrichmentLoggerTest extends TestCase
+{
+    public function test_log_creates_new_entry_when_none_exists(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($this->createConfiguredMock(
+            EnrichmentLog::class,
+            ['getId' => null]
+        ));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $newLog = $this->createMock(EnrichmentLog::class);
+        $newLog->expects($this->once())->method('setData')->with($this->callback(
+            fn(array $data) => $data['entity_id'] === 42
+                && $data['attribute_code'] === 'description'
+                && $data['store_id'] === 1
+                && $data['status'] === EnrichmentLog::STATUS_GENERATED
+        ));
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $logFactory->method('create')->willReturn($newLog);
+
+        $resource = $this->createMock(EnrichmentLogResource::class);
+        $resource->expects($this->once())->method('save')->with($newLog);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $logger->log(42, 'description', 1);
+    }
+}

--- a/Test/Unit/Model/Product/PromptResolverTest.php
+++ b/Test/Unit/Model/Product/PromptResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+use Magento\Catalog\Model\Product;
+use PHPUnit\Framework\TestCase;
+
+final class PromptResolverTest extends TestCase
+{
+    public function test_returns_highest_priority_matching_rule_prompt(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $lowRule = $this->createMock(PromptRule::class);
+        $lowRule->method('getIsActive')->willReturn(true);
+        $lowRule->method('getPriority')->willReturn(10);
+        $lowRule->method('getPrompt')->willReturn('low priority prompt');
+        $lowRule->method('matchesStore')->willReturn(true);
+        $lowRule->method('matchesProduct')->willReturn(true);
+
+        $highRule = $this->createMock(PromptRule::class);
+        $highRule->method('getIsActive')->willReturn(true);
+        $highRule->method('getPriority')->willReturn(50);
+        $highRule->method('getPrompt')->willReturn('high priority prompt');
+        $highRule->method('matchesStore')->willReturn(true);
+        $highRule->method('matchesProduct')->willReturn(true);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([$highRule, $lowRule]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('high priority prompt', $result);
+    }
+
+    public function test_falls_back_to_config_when_no_rule_matches(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+        $config->method('getProductPrompt')
+            ->with('description')
+            ->willReturn('default config prompt');
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('default config prompt', $result);
+    }
+}

--- a/Test/Unit/Model/Product/RequestTest.php
+++ b/Test/Unit/Model/Product/RequestTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_request_carries_store_id(): void
+    {
+        $request = new Request(42, true, 3);
+
+        $this->assertEquals(42, $request->getId());
+        $this->assertTrue($request->getOverwrite());
+        $this->assertEquals(3, $request->getStoreId());
+    }
+
+    public function test_store_id_defaults_to_zero(): void
+    {
+        $request = new Request(42, false);
+
+        $this->assertEquals(0, $request->getStoreId());
+    }
+}

--- a/Ui/Component/Listing/Column/PromptRuleActions.php
+++ b/Ui/Component/Listing/Column/PromptRuleActions.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class PromptRuleActions extends Column
+{
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        private readonly UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                if (isset($item['rule_id'])) {
+                    $item[$this->getData('name')] = [
+                        'edit' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/edit',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Edit'),
+                        ],
+                        'delete' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/delete',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Delete'),
+                            'confirm' => [
+                                'title' => __('Delete Rule'),
+                                'message' => __('Are you sure you want to delete this rule?'),
+                            ],
+                        ],
+                    ];
+                }
+            }
+        }
+        return $dataSource;
+    }
+}

--- a/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
+++ b/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\Framework\Stdlib\ArrayManager;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class EnrichmentStatus extends AbstractModifier
+{
+    public function __construct(
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly Config $config,
+        private readonly ArrayManager $arrayManager
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            $containerPath = $this->arrayManager->findPath(
+                $attributeCode,
+                $meta,
+                null,
+                'children'
+            );
+
+            if ($containerPath) {
+                $meta = $this->arrayManager->merge(
+                    $containerPath . '/arguments/data/config',
+                    $meta,
+                    [
+                        'additionalClasses' => 'mageos-catalogai-enriched-field',
+                    ]
+                );
+            }
+        }
+
+        return $meta;
+    }
+}

--- a/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
+++ b/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Conditions implements ModifierInterface
+{
+    public function __construct(
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId && isset($data[$ruleId])) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            $conditions = $rule->getConditions()->asArray();
+            $data[$ruleId]['rule']['conditions'] = $this->convertConditions($conditions);
+        }
+
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $meta['conditions_fieldset'] = [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Conditions'),
+                        'componentType' => 'fieldset',
+                        'collapsible' => true,
+                        'sortOrder' => 20,
+                    ],
+                ],
+            ],
+            'children' => [
+                'conditions_notice' => [
+                    'arguments' => [
+                        'data' => [
+                            'config' => [
+                                'componentType' => 'container',
+                                'component' => 'Magento_Ui/js/form/components/html',
+                                'content' => (string)__(
+                                    'Define product conditions that must match for this rule to apply. '
+                                    . 'If no conditions are set, the rule applies to all products.'
+                                ),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $meta;
+    }
+
+    private function convertConditions(array $conditions): array
+    {
+        $result = [];
+        if (isset($conditions['type'])) {
+            $result['type'] = $conditions['type'];
+            $result['attribute'] = $conditions['attribute'] ?? '';
+            $result['operator'] = $conditions['operator'] ?? '';
+            $result['value'] = $conditions['value'] ?? '';
+            $result['aggregator'] = $conditions['aggregator'] ?? 'all';
+            if (isset($conditions['conditions'])) {
+                foreach ($conditions['conditions'] as $key => $condition) {
+                    $result['conditions'][$key] = $this->convertConditions($condition);
+                }
+            }
+        }
+        return $result;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
             "homepage": "https://www.sunmerce.com/"
         }
     ],
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://mirror.mage-os.org"
-        }
-    ],
     "require": {
         "php": "^8.1",
-        "openai-php/client": "*"
+        "openai-php/client": "*",
+        "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-ui": "*",
+        "magento/module-backend": "*",
+        "magento/module-config": "*",
+        "magento/module-store": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/docs/plans/2026-04-14-feature-roadmap-design.md
+++ b/docs/plans/2026-04-14-feature-roadmap-design.md
@@ -1,0 +1,133 @@
+# Feature Roadmap Design — MageOS_CatalogDataAI
+
+**Date:** 2026-04-14
+**Approach:** Quick Wins, Then Depth
+**BC policy:** Pragmatic — data patches for migration, old paths can break, documented in release notes
+
+---
+
+## Phase 1: Housekeeping + Configurable Attributes
+
+**Issues:** #23, #22, #25, #27
+
+### Housekeeping
+
+- Run PHP-CS-Fixer with PSR-12/Magento rules across all files
+- Fix `system.xml` temperature field: change label from "System Prompt" to "Temperature", add `<comment>` tags to all advanced fields explaining valid ranges
+- Fix `composer.json`: add explicit Magento module dependencies (`magento/framework`, `magento/module-catalog`, `magento/module-ui`, `magento/module-backend`), remove the mirror repository entry, keep `phpunit` in require-dev
+
+### Configurable Attributes
+
+Replace the hardcoded attribute list and static `system.xml` fields with a dynamic row configuration.
+
+- **New admin config**: Replace the 5 fixed textarea fields under "Product Fields Auto-Generation" with a dynamic row table with columns:
+  - **Attribute** — dropdown of product text/textarea attributes
+  - **Prompt** — textarea for the prompt template
+  - **Enabled** — yes/no toggle per attribute
+- **Data patch**: Migrate existing `catalog_ai/product/*` config values into the new dynamic row format
+- **Enricher refactor**: `getAttributes()` reads from the dynamic config instead of returning a hardcoded array. `enrichAttribute()` stays the same — it already takes an attribute code and looks up the prompt from config
+- **Config model**: `getProductPrompt()` adapts to read from the serialized dynamic row data instead of individual config paths
+- **Default rows**: Pre-populate the same 5 attributes (short_description, description, meta_title, meta_keyword, meta_description) with their current default prompts
+
+---
+
+## Phase 2: Multi-Store/Locale + Enrichment Status Flags
+
+**Issues:** #12, #48
+
+### Multi-Store/Locale
+
+- **Locale-aware prompts**: Detect the store's locale (`general/locale/code`) and prepend "Respond in {locale language}" to the system prompt when enriching for a store
+- **Store-scoped enrichment**: `Publisher`/`Request` DTO gets a `storeId` field. `Consumer` sets the correct store scope before enriching so config values resolve per-store. Mass actions enrich for the selected store scope
+- **Data patch**: Add `storeId` to the `Request` queue message format with default of `0` for backward compatibility with in-flight messages
+
+### Enrichment Status Flags
+
+- **New DB table**: `mageos_catalogai_enrichment_log` with columns: `entity_id` (product ID), `attribute_code`, `store_id`, `status` (enum: `generated`, `pending_review`, `modified`), `generated_at`, `updated_at`
+- **Write on enrich**: When `Enricher` successfully sets an attribute value, write/update a log row with status `generated`
+- **Detect manual edits**: In `SaveBefore` observer, if an enriched attribute's value changed and it wasn't the enricher doing it, flip status to `modified`
+- **Admin UI indicator**: On the product edit form, add a small badge/note next to enriched fields showing their status via a UI component modifier
+- No blocking review workflow yet — that's Phase 4. This phase just tracks and displays status.
+
+---
+
+## Phase 3: Prompt Rules Engine + Config Migration
+
+**Issues:** #32, #43
+
+### Prompt Rules Engine
+
+- **New admin grid**: "AI Prompt Rules" grid. Each rule has:
+  - **Name** — human-readable label
+  - **Attribute** — which attribute this prompt targets
+  - **Store scope(s)** — multiselect, default: all
+  - **Conditions** — product conditions using Magento's existing condition engine (same as catalog price rules)
+  - **Prompt** — template with `{{variable}}` support
+  - **Priority** — integer, highest wins
+  - **Enabled** — yes/no
+- **Rule resolution**: Collect all matching enabled rules for attribute+store, sort by priority, use highest. Fall back to default prompt from Phase 1's dynamic rows if no rule matches.
+- **Preview/test**: On the rule edit form, "Test" button — enter a SKU, see the resolved prompt + API response
+- **Storage**: New DB tables for rules and conditions (entities, not config)
+- **Phase 1 compatibility**: Dynamic row config becomes "default prompts" — rules layer on top, no migration needed
+
+### Config Migration
+
+- **New section**: `ai_integration` under the Services tab, matching the translation module's structure
+- **Group**: "Data Enrichment" group within that section
+- **Data patch**: Migrate all `catalog_ai/*` config values to the new path
+- **No legacy path support** — document in release notes
+
+---
+
+## Phase 4: Review/Approval Workflow
+
+**Issues:** #28
+
+### Enrichment Review Grid
+
+- **Admin grid**: "AI Enrichment Review" under the AI Integration section. Columns: product name/SKU, attribute, store, status, generated content (truncated), generated date. Filterable by status, store, attribute.
+- **Inline editing**: Admin clicks into a row to see full content, edit, approve, or reject
+- **Statuses expand**: Phase 2 statuses gain `approved` and `rejected`. Rejected clears or reverts the attribute value.
+- **Original value backup**: Before enrichment overwrites, store the previous value in the log table for revert on rejection
+- **Review mode config**: Toggle "Require review before publish". When enabled:
+  - Enricher writes to log with `pending_review` but does NOT set on the product
+  - Admin approves in grid -> content written to product and saved
+- **Bulk grid actions**: Approve selected, reject selected, re-generate selected
+
+### Content Deduplication
+
+- **Hash tracking**: Compute hash of resolved prompt (after variable substitution), store in log alongside generated output
+- **Cache hit**: Before calling OpenAI, check for existing log entry with same prompt hash + attribute + store. Reuse if found.
+- **Cache invalidation**: Prompt or source data changes -> hash won't match -> fresh API call. No manual cache management.
+
+---
+
+## Phase 5: Structured Attribute Extraction
+
+**Issues:** #7
+
+### Attribute Extraction
+
+- **New enrichment type**: "Attribute Extraction" alongside "Content Generation". Separate config/rules — prompt engineering is fundamentally different (extract/classify vs. create).
+- **Attribute mapping config**: Admin defines extraction rules:
+  - **Source attribute(s)** — where to read from (e.g., description)
+  - **Target attribute** — attribute to fill (dropdown, multiselect, boolean, text, decimal)
+  - **Extraction prompt** — instructions for the AI
+  - **Value mapping** — for dropdowns/multiselects: map AI output strings to option IDs, supports fuzzy matching
+  - **Conditions** — reuse Phase 3 conditions engine
+- **Structured output**: Use OpenAI's JSON mode (`response_format: { type: "json_object" }`) for reliable structured responses
+- **Validation**: Validate extracted value against attribute constraints before writing. Log failures.
+- **Review integration**: Extracted values go through Phase 4 review flow, defaulting to `pending_review` status
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|---|---|
+| Keep per-attribute API calls (not unified) | Per-attribute prompts give more control, especially with the rules engine where different attributes may need completely different prompts per store/category/language |
+| Pragmatic BC, no legacy config paths | Avoids carrying dead weight; data patches handle migration cleanly |
+| Dynamic rows before rules engine | Dynamic rows is a quick win that unblocks configurable attributes; rules engine layers on top later |
+| Config migration paired with rules engine | Both touch prompt storage/admin structure — one release reshuffles the admin experience |
+| Review workflow as Phase 4 | Needs the enrichment log from Phase 2 and benefits from the rules engine in Phase 3 |
+| Structured extraction last | Most experimental feature, benefits from all prior infrastructure (rules, review, configurable attributes) |

--- a/docs/plans/2026-04-14-phase1-implementation.md
+++ b/docs/plans/2026-04-14-phase1-implementation.md
@@ -1,0 +1,879 @@
+# Phase 1: Housekeeping + Configurable Attributes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix code style, composer deps, and system.xml label issues, then replace the hardcoded 5-attribute enrichment list with a dynamic row configuration that lets admins enrich any text attribute.
+
+**Architecture:** The dynamic rows feature replaces the static `catalog_ai/product/*` config fields with a single serialized field using Magento's `AbstractFieldArray` + `ArraySerialized` backend model. A custom select renderer provides an attribute dropdown. The `Config` model and `Enricher` are updated to read from the new serialized format. A data patch migrates existing config.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, PHPUnit 9.5
+
+---
+
+### Task 1: Fix composer.json
+
+**Files:**
+- Modify: `composer.json`
+
+**Step 1: Update composer.json**
+
+Replace the entire content of `composer.json` with:
+
+```json
+{
+    "name": "mage-os/module-catalog-data-ai",
+    "description": "Generate product descriptions and similar content with the help of AI.",
+    "type": "magento2-module",
+    "license": [
+        "MIT"
+    ],
+    "authors": [
+        {
+            "name": "Ryan Sun",
+            "email": "ryansun81@gmail.com",
+            "homepage": "https://www.sunmerce.com/"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "openai-php/client": "*",
+        "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-ui": "*",
+        "magento/module-backend": "*",
+        "magento/module-config": "*",
+        "magento/module-store": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "MageOS\\CatalogDataAI\\": ""
+        }
+    }
+}
+```
+
+Changes from current:
+- Removed `repositories` block (the mage-os mirror is not needed for the package itself)
+- Added explicit Magento module dependencies: `magento/framework`, `magento/module-catalog`, `magento/module-ui`, `magento/module-backend`, `magento/module-config`, `magento/module-store`
+
+**Step 2: Commit**
+
+```bash
+git add composer.json
+git commit -m "fix: add explicit Magento module dependencies, remove mirror repo (#22)"
+```
+
+---
+
+### Task 2: Fix system.xml labels and comments
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml:62-75`
+
+**Step 1: Fix the temperature label and add comments to advanced fields**
+
+In `etc/adminhtml/system.xml`, replace the `advanced` group (lines 61-76) with:
+
+```xml
+            <group id="advanced" translate="label" sortOrder="30" showInDefault="1">
+                <label>Advanced Settings</label>
+                <field id="system_prompt" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
+                    <label>System Prompt</label>
+                    <comment><![CDATA[Instructions sent to the AI model as the developer/system role. Defines the AI's behavior.]]></comment>
+                </field>
+                <field id="temperature" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
+                    <label>Temperature</label>
+                    <comment><![CDATA[Controls randomness. 0.0 = deterministic, 1.0 = creative. Default: 0]]></comment>
+                </field>
+                <field id="frequency_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
+                    <label>Frequency Penalty</label>
+                    <comment><![CDATA[Reduces repetition of token sequences. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+                <field id="presence_penalty" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
+                    <label>Presence Penalty</label>
+                    <comment><![CDATA[Encourages new topics. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+            </group>
+```
+
+Key changes:
+- Temperature `<label>` changed from "System Prompt" to "Temperature"
+- Added `<comment>` to all 4 advanced fields explaining valid ranges
+- Presence penalty `sortOrder` changed from `30` to `40` (was duplicate)
+
+**Step 2: Commit**
+
+```bash
+git add etc/adminhtml/system.xml
+git commit -m "fix: correct temperature label, add range comments to advanced fields (#25)"
+```
+
+---
+
+### Task 3: Run PHP-CS-Fixer
+
+**Files:**
+- Modify: all `.php` files
+
+**Step 1: Install PHP-CS-Fixer (if not available globally)**
+
+```bash
+composer global require friendsofphp/php-cs-fixer --dev
+```
+
+**Step 2: Create a `.php-cs-fixer.dist.php` config at module root**
+
+Create file `.php-cs-fixer.dist.php`:
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'single_quote' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    ])
+    ->setFinder($finder);
+```
+
+**Step 3: Run the fixer**
+
+```bash
+php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff
+```
+
+Review the diff to make sure nothing weird happened. The changes should be whitespace, brace placement, and import ordering only.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "style: apply PSR-12 code style fixes (#23)"
+```
+
+---
+
+### Task 4: Create the attribute column select renderer
+
+**Files:**
+- Create: `Block/Adminhtml/Form/Field/AttributeColumn.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Block\Adminhtml\Form\Field;
+
+use MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\AttributeColumn;
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchResultsInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeColumnTest extends TestCase
+{
+    public function test_get_options_returns_text_and_textarea_attributes(): void
+    {
+        $attribute1 = $this->createMock(ProductAttributeInterface::class);
+        $attribute1->method('getAttributeCode')->willReturn('description');
+        $attribute1->method('getDefaultFrontendLabel')->willReturn('Description');
+
+        $attribute2 = $this->createMock(ProductAttributeInterface::class);
+        $attribute2->method('getAttributeCode')->willReturn('short_description');
+        $attribute2->method('getDefaultFrontendLabel')->willReturn('Short Description');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$attribute1, $attribute2]);
+
+        $searchCriteria = $this->createMock(SearchCriteria::class);
+
+        $searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $searchCriteriaBuilder->method('addFilter')->willReturnSelf();
+        $searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $attributeRepository = $this->createMock(ProductAttributeRepositoryInterface::class);
+        $attributeRepository->method('getList')->willReturn($searchResults);
+
+        $column = new AttributeColumn($attributeRepository, $searchCriteriaBuilder);
+        $options = $column->getOptions();
+
+        $this->assertArrayHasKey('description', $options);
+        $this->assertArrayHasKey('short_description', $options);
+        $this->assertEquals('Description', $options['description']);
+        $this->assertEquals('Short Description', $options['short_description']);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+```
+
+Expected: FAIL — class `AttributeColumn` does not exist.
+
+**Step 3: Write the implementation**
+
+Create file `Block/Adminhtml/Form/Field/AttributeColumn.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\View\Element\Html\Select;
+use Magento\Framework\View\Element\Context;
+
+class AttributeColumn extends Select
+{
+    private array $options = [];
+
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
+        Context $context = null,
+        array $data = []
+    ) {
+        // Context may be null in unit tests
+        if ($context !== null) {
+            parent::__construct($context, $data);
+        }
+    }
+
+    public function getOptions(): array
+    {
+        if (empty($this->options)) {
+            $searchCriteria = $this->searchCriteriaBuilder
+                ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+                ->create();
+
+            $attributes = $this->attributeRepository->getList($searchCriteria);
+
+            foreach ($attributes->getItems() as $attribute) {
+                $this->options[$attribute->getAttributeCode()] = $attribute->getDefaultFrontendLabel()
+                    ?? $attribute->getAttributeCode();
+            }
+
+            asort($this->options);
+        }
+
+        return $this->options;
+    }
+
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            $this->setOptions($this->getOptions());
+        }
+
+        foreach ($this->getOptions() as $code => $label) {
+            $this->addOption($code, $label);
+        }
+
+        return parent::_toHtml();
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Block/Adminhtml/Form/Field/AttributeColumn.php Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php
+git commit -m "feat: add attribute column select renderer for dynamic rows (#27)"
+```
+
+---
+
+### Task 5: Create the dynamic rows field array block
+
+**Files:**
+- Create: `Block/Adminhtml/Form/Field/ProductAttributes.php`
+
+**Step 1: Write the implementation**
+
+This block is mostly wiring — Magento's `AbstractFieldArray` does the heavy lifting. No meaningful unit test possible without the full layout system.
+
+Create file `Block/Adminhtml/Form/Field/ProductAttributes.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class ProductAttributes extends AbstractFieldArray
+{
+    private ?AttributeColumn $attributeRenderer = null;
+
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn('attribute', [
+            'label' => __('Attribute'),
+            'renderer' => $this->getAttributeRenderer(),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('prompt', [
+            'label' => __('Prompt'),
+            'class' => 'required-entry',
+        ]);
+        $this->addColumn('enabled', [
+            'label' => __('Enabled'),
+            'class' => 'required-entry',
+        ]);
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Attribute');
+    }
+
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+        $attribute = $row->getData('attribute');
+
+        if ($attribute !== null) {
+            $key = 'option_' . $this->getAttributeRenderer()->calcOptionHash($attribute);
+            $options[$key] = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+
+    /**
+     * @throws LocalizedException
+     */
+    private function getAttributeRenderer(): AttributeColumn
+    {
+        if ($this->attributeRenderer === null) {
+            $this->attributeRenderer = $this->getLayout()->createBlock(
+                AttributeColumn::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->attributeRenderer;
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Block/Adminhtml/Form/Field/ProductAttributes.php
+git commit -m "feat: add dynamic rows field array block for product attributes (#27)"
+```
+
+---
+
+### Task 6: Update system.xml — replace static fields with dynamic rows
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml:38-59`
+
+**Step 1: Replace the product group**
+
+In `etc/adminhtml/system.xml`, replace the entire `product` group (lines 38-59) with:
+
+```xml
+            <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
+                <label>Product Fields Auto-Generation</label>
+                <comment>
+                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name) as product attribute data placeholder.
+                    <br />
+                    To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
+                </comment>
+                <field id="attribute_prompts" translate="label" sortOrder="10" showInDefault="1" showInStore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\ProductAttributes</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
+                </field>
+            </group>
+```
+
+This replaces the 5 individual textarea fields with a single dynamic rows field.
+
+**Step 2: Commit**
+
+```bash
+git add etc/adminhtml/system.xml
+git commit -m "feat: replace static product fields with dynamic rows config (#27)"
+```
+
+---
+
+### Task 7: Update config.xml — default values in dynamic row format
+
+**Files:**
+- Modify: `etc/config.xml:11-15`
+
+**Step 1: Replace the product defaults**
+
+In `etc/config.xml`, replace the `<product>` block (lines 11-15) with:
+
+```xml
+            <product>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute>short_description</attribute>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                        <enabled>1</enabled>
+                    </short_description>
+                    <description>
+                        <attribute>description</attribute>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                        <enabled>1</enabled>
+                    </description>
+                    <meta_title>
+                        <attribute>meta_title</attribute>
+                        <prompt>write a concise SEO meta title for {{name}}, under 60 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_title>
+                    <meta_keyword>
+                        <attribute>meta_keyword</attribute>
+                        <prompt>generate comma-separated SEO keywords for {{name}}, max 10 keywords</prompt>
+                        <enabled>1</enabled>
+                    </meta_keyword>
+                    <meta_description>
+                        <attribute>meta_description</attribute>
+                        <prompt>write an SEO meta description for {{name}}, under 160 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_description>
+                </attribute_prompts>
+            </product>
+```
+
+Note: `meta_title`, `meta_keyword`, and `meta_description` previously had no default prompts. We're adding sensible defaults now since the dynamic rows format requires a prompt value per row.
+
+**Step 2: Commit**
+
+```bash
+git add etc/config.xml
+git commit -m "feat: add default dynamic row values for all 5 enrichable attributes (#27)"
+```
+
+---
+
+### Task 8: Update Config model to read dynamic rows
+
+**Files:**
+- Modify: `Model/Config.php:74-80`
+- Test: `Test/Unit/Model/ConfigTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/ConfigTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model;
+
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    private ScopeConfigInterface $scopeConfig;
+    private Config $config;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->config = new Config($this->scopeConfig);
+    }
+
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+        $this->assertEquals('describe {{name}}', $result['description']);
+        $this->assertEquals('short desc for {{name}}', $result['short_description']);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn(null);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->with('catalog_ai/product/attribute_prompts')
+            ->willReturn($serializedData);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/ConfigTest.php
+```
+
+Expected: FAIL — `getEnrichableAttributes` method does not exist.
+
+**Step 3: Update Config model**
+
+In `Model/Config.php`, replace the `getProductPrompt` method (lines 74-80) with two new methods:
+
+```php
+    public function getEnrichableAttributes(): array
+    {
+        $rows = $this->scopeConfig->getValue(
+            'catalog_ai/product/attribute_prompts'
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach ($rows as $row) {
+            if (isset($row['attribute'], $row['prompt'], $row['enabled']) && (int)$row['enabled'] === 1) {
+                $attributes[$row['attribute']] = $row['prompt'];
+            }
+        }
+
+        return $attributes;
+    }
+
+    public function getProductPrompt(string $attributeCode): ?string
+    {
+        $attributes = $this->getEnrichableAttributes();
+
+        return $attributes[$attributeCode] ?? null;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/ConfigTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "feat: update Config to read attribute prompts from dynamic rows (#27)"
+```
+
+---
+
+### Task 9: Update Enricher to use dynamic config
+
+**Files:**
+- Modify: `Model/Product/Enricher.php:36-45`
+- Test: `Test/Unit/Model/Product/EnricherTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/EnricherTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Config;
+use Magento\Catalog\Model\Product;
+use OpenAI\Factory;
+use PHPUnit\Framework\TestCase;
+
+final class EnricherTest extends TestCase
+{
+    public function test_get_attributes_returns_enabled_attribute_codes_from_config(): void
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('getEnrichableAttributes')->willReturn([
+            'description' => 'describe {{name}}',
+            'custom_field' => 'generate {{name}} custom',
+        ]);
+
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $this->assertEquals(['description', 'custom_field'], $enricher->getAttributes());
+    }
+
+    public function test_parse_prompt_replaces_placeholders_with_product_data(): void
+    {
+        $config = $this->createMock(Config::class);
+        $factory = $this->createMock(Factory::class);
+        $enricher = new Enricher($factory, $config);
+
+        $product = $this->createMock(Product::class);
+        $product->method('getData')
+            ->willReturnMap([
+                ['name', null, 'Cool Widget'],
+                ['price', null, '29.99'],
+            ]);
+
+        $result = $enricher->parsePrompt('describe {{name}} at {{price}}', $product);
+
+        $this->assertEquals('describe Cool Widget at 29.99', $result);
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/Product/EnricherTest.php
+```
+
+Expected: FAIL — `getAttributes()` returns hardcoded array, not config-driven.
+
+**Step 3: Update Enricher**
+
+In `Model/Product/Enricher.php`, replace the `getAttributes` method (lines 36-45) with:
+
+```php
+    public function getAttributes(): array
+    {
+        return array_keys($this->config->getEnrichableAttributes());
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+vendor/bin/phpunit Test/Unit/Model/Product/EnricherTest.php
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Model/Product/Enricher.php Test/Unit/Model/Product/EnricherTest.php
+git commit -m "feat: Enricher reads attribute list from dynamic config (#27)"
+```
+
+---
+
+### Task 10: Create data patch to migrate existing config
+
+**Files:**
+- Create: `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php`
+
+**Step 1: Write the data patch**
+
+Create file `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+
+class MigrateProductPromptsToDynamicRows implements DataPatchInterface
+{
+    private const OLD_ATTRIBUTE_PATHS = [
+        'short_description',
+        'description',
+        'meta_title',
+        'meta_keyword',
+        'meta_description',
+    ];
+
+    private const NEW_PATH = 'catalog_ai/product/attribute_prompts';
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter,
+        private readonly Json $json
+    ) {
+    }
+
+    public function apply(): self
+    {
+        $rows = [];
+        $hasExistingConfig = false;
+
+        foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+            $oldPath = 'catalog_ai/product/' . $attributeCode;
+            $value = $this->scopeConfig->getValue($oldPath);
+
+            if ($value !== null && $value !== '') {
+                $hasExistingConfig = true;
+                $rows[$attributeCode] = [
+                    'attribute' => $attributeCode,
+                    'prompt' => $value,
+                    'enabled' => '1',
+                ];
+            }
+        }
+
+        if ($hasExistingConfig) {
+            $this->configWriter->save(self::NEW_PATH, $this->json->serialize($rows));
+
+            // Clean up old paths
+            foreach (self::OLD_ATTRIBUTE_PATHS as $attributeCode) {
+                $this->configWriter->delete('catalog_ai/product/' . $attributeCode);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php
+git commit -m "feat: add data patch to migrate old product prompts to dynamic rows (#27)"
+```
+
+---
+
+### Task 11: Smoke test — setup:upgrade and di:compile
+
+**Step 1: Run Magento setup commands**
+
+From the Magento root directory:
+
+```bash
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+```
+
+Both should complete without errors. If `di:compile` fails, check the constructor signatures in the new block classes — Magento's DI compiler is strict about type hints.
+
+**Step 2: Verify in admin**
+
+1. Go to **Stores > Configuration > Catalog > AI Data Enrichment > Product Fields Auto-Generation**
+2. Verify the dynamic rows table renders with the 5 default attributes
+3. Verify the attribute dropdown loads product text/textarea attributes
+4. Try adding a new row, saving, and reloading — confirm persistence
+
+**Step 3: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+Expected: All tests pass.
+
+**Step 4: Final commit (if any adjustments were needed)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 1"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| Modify | `composer.json` |
+| Modify | `etc/adminhtml/system.xml` |
+| Modify | `etc/config.xml` |
+| Modify | `Model/Config.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Create | `.php-cs-fixer.dist.php` |
+| Create | `Block/Adminhtml/Form/Field/AttributeColumn.php` |
+| Create | `Block/Adminhtml/Form/Field/ProductAttributes.php` |
+| Create | `Setup/Patch/Data/MigrateProductPromptsToDynamicRows.php` |
+| Create | `Test/Unit/Block/Adminhtml/Form/Field/AttributeColumnTest.php` |
+| Create | `Test/Unit/Model/ConfigTest.php` |
+| Create | `Test/Unit/Model/Product/EnricherTest.php` |

--- a/docs/plans/2026-04-14-phase2-implementation.md
+++ b/docs/plans/2026-04-14-phase2-implementation.md
@@ -1,0 +1,1106 @@
+# Phase 2: Multi-Store/Locale + Enrichment Status Flags — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add store-scoped enrichment with locale-aware AI output, and track which product attributes were AI-generated with status indicators in the admin product edit form.
+
+**Architecture:** The `Request` DTO gains a `storeId` field so queue messages carry store context. `Consumer` sets the store scope before enriching, and `Config` resolves the store's locale to inject language instructions into the system prompt. A new `mageos_catalogai_enrichment_log` DB table tracks enrichment status per product/attribute/store. The `Enricher` writes log entries on successful enrichment, and a `SaveBefore` observer detects manual edits to enriched fields. A UI component modifier adds status badges to the product edit form.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, PHPUnit 9.5, Magento Declarative Schema (`db_schema.xml`)
+
+---
+
+### Task 1: Add storeId to RequestInterface and Request DTO
+
+**Files:**
+- Modify: `Api/RequestInterface.php`
+- Modify: `Model/Product/Request.php`
+- Test: `Test/Unit/Model/Product/RequestTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/RequestTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_request_carries_store_id(): void
+    {
+        $request = new Request(42, true, 3);
+
+        $this->assertEquals(42, $request->getId());
+        $this->assertTrue($request->getOverwrite());
+        $this->assertEquals(3, $request->getStoreId());
+    }
+
+    public function test_store_id_defaults_to_zero(): void
+    {
+        $request = new Request(42, false);
+
+        $this->assertEquals(0, $request->getStoreId());
+    }
+}
+```
+
+**Step 2: Update RequestInterface**
+
+In `Api/RequestInterface.php`, add the `getStoreId` method to the interface:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api;
+
+interface RequestInterface
+{
+    /**
+     * Retrieve product id.
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * Retrieve overwrite flag.
+     * @return bool
+     */
+    public function getOverwrite(): bool;
+
+    /**
+     * Retrieve store id.
+     * @return int
+     */
+    public function getStoreId(): int;
+}
+```
+
+**Step 3: Update Request DTO**
+
+Replace `Model/Product/Request.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Api\RequestInterface;
+
+/**
+ * Data model for enrichment message queue.
+ */
+class Request implements RequestInterface
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly bool $overwrite,
+        private readonly int $storeId = 0
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getOverwrite(): bool
+    {
+        return $this->overwrite;
+    }
+
+    public function getStoreId(): int
+    {
+        return $this->storeId;
+    }
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add Api/RequestInterface.php Model/Product/Request.php Test/Unit/Model/Product/RequestTest.php
+git commit -m "feat: add storeId to Request DTO for store-scoped enrichment (#12)"
+```
+
+---
+
+### Task 2: Update Publisher to pass storeId
+
+**Files:**
+- Modify: `Model/Product/Publisher.php`
+
+**Step 1: Update Publisher::execute signature and pass storeId to Request**
+
+Replace `Model/Product/Publisher.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Framework\MessageQueue\PublisherInterface;
+
+class Publisher
+{
+    public const TOPIC_NAME = 'mageos.product.enrich';
+
+    public function __construct(
+        private readonly PublisherInterface $publisher,
+        private readonly RequestFactory     $requestFactory,
+    ) {
+    }
+
+    public function execute(int|string $productId, bool $overwrite = false, int $storeId = 0): void
+    {
+        $request = $this->requestFactory->create([
+            'id' => (int)$productId,
+            'overwrite' => $overwrite,
+            'storeId' => $storeId,
+        ]);
+        $this->publisher->publish(self::TOPIC_NAME, $request);
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Publisher.php
+git commit -m "feat: Publisher passes storeId to queue messages (#12)"
+```
+
+---
+
+### Task 3: Update Consumer to set store scope
+
+**Files:**
+- Modify: `Model/Product/Consumer.php`
+
+**Step 1: Update Consumer to use storeId from request**
+
+Replace `Model/Product/Consumer.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Consumer
+{
+    public function __construct(
+        private readonly Enricher              $enricher,
+        private readonly ProductRepository     $productRepository,
+        private readonly StoreManagerInterface $storeManager
+    ) {
+    }
+
+    public function execute(Request $request): void
+    {
+        $this->storeManager->setCurrentStore($request->getStoreId());
+        $product = $this->productRepository->getById(
+            $request->getId(),
+            false,
+            $request->getStoreId()
+        );
+        $product->setData('mageos_catalogai_overwrite', $request->getOverwrite());
+        $this->enricher->execute($product);
+        $this->productRepository->save($product);
+    }
+}
+```
+
+Key changes:
+- Uses `$request->getStoreId()` instead of hardcoded `0`
+- Passes `storeId` to `getById()` third parameter so product data loads for the correct store
+- Removed the stale `@package` docblock
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Consumer.php
+git commit -m "feat: Consumer sets store scope from queue message (#12)"
+```
+
+---
+
+### Task 4: Update SaveAfter observer to pass storeId
+
+**Files:**
+- Modify: `Observer/Product/SaveAfter.php`
+
+**Step 1: Pass the product's store ID to the publisher**
+
+In `Observer/Product/SaveAfter.php`, change the `execute` method to pass the store ID:
+
+```php
+    public function execute(Observer $observer): void
+    {
+        /** @var Product $product */
+        $product = $observer->getProduct();
+
+        if ($this->config->canEnrich($product) && $this->config->isAsync()) {
+            $this->publisher->execute(
+                $product->getId(),
+                false,
+                (int)$product->getStoreId()
+            );
+        }
+    }
+```
+
+**Step 2: Commit**
+
+```bash
+git add Observer/Product/SaveAfter.php
+git commit -m "feat: SaveAfter observer passes storeId to publisher (#12)"
+```
+
+---
+
+### Task 5: Update MassEnrich controller to pass storeId
+
+**Files:**
+- Modify: `Controller/Adminhtml/Product/MassEnrich.php`
+
+**Step 1: Inject StoreManagerInterface and pass current store to publisher**
+
+Add `StoreManagerInterface` to the constructor and pass the current store ID in the loop:
+
+In the constructor, add after `ProductRepositoryInterface`:
+```php
+        private readonly \Magento\Store\Model\StoreManagerInterface $storeManager,
+```
+
+In the `execute()` method, before the foreach loop, get the current store:
+```php
+        $storeId = (int)$this->storeManager->getStore()->getId();
+```
+
+In the foreach loop, change:
+```php
+                $this->publisher->execute($product->getId(), $this->overwrite);
+```
+to:
+```php
+                $this->publisher->execute($product->getId(), $this->overwrite, $storeId);
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/Product/MassEnrich.php
+git commit -m "feat: MassEnrich passes current store scope to publisher (#12)"
+```
+
+---
+
+### Task 6: Add locale-aware system prompt to Config
+
+**Files:**
+- Modify: `Model/Config.php`
+- Test: `Test/Unit/Model/ConfigTest.php`
+
+**Step 1: Write the test**
+
+Add this test to the existing `Test/Unit/Model/ConfigTest.php`:
+
+```php
+    public function test_get_system_prompt_includes_locale_language(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'fr_FR'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertStringContainsString('Respond in French', $result);
+        $this->assertStringContainsString('Be a content generator.', $result);
+    }
+
+    public function test_get_system_prompt_without_locale_returns_base_prompt(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertEquals('Be a content generator.', $result);
+    }
+```
+
+Add this import at the top of the test file:
+```php
+use Magento\Store\Model\ScopeInterface;
+```
+
+Also update the `setUp()` method — the existing tests use `->method('getValue')->with(...)` which will conflict with the new `willReturnMap`. The tests need to be refactored. Replace the two existing `getEnrichableAttributes` tests and the `getProductPrompt` test so they also use `willReturnMap`:
+
+```php
+    public function test_get_enrichable_attributes_returns_enabled_attributes(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '0'],
+            'row3' => ['attribute' => 'short_description', 'prompt' => 'short desc for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertArrayHasKey('short_description', $result);
+        $this->assertArrayNotHasKey('meta_title', $result);
+    }
+
+    public function test_get_enrichable_attributes_returns_empty_when_null(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, null],
+            ]);
+
+        $result = $this->config->getEnrichableAttributes();
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_get_product_prompt_returns_prompt_for_attribute(): void
+    {
+        $serializedData = [
+            'row1' => ['attribute' => 'description', 'prompt' => 'describe {{name}}', 'enabled' => '1'],
+            'row2' => ['attribute' => 'meta_title', 'prompt' => 'title for {{name}}', 'enabled' => '1'],
+        ];
+
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['catalog_ai/product/attribute_prompts', ScopeInterface::SCOPE_STORE, null, $serializedData],
+            ]);
+
+        $this->assertEquals('describe {{name}}', $this->config->getProductPrompt('description'));
+        $this->assertNull($this->config->getProductPrompt('nonexistent'));
+    }
+```
+
+**Step 2: Update Config::getSystemPrompt()**
+
+In `Model/Config.php`, add a locale-to-language map constant and update `getSystemPrompt()`:
+
+Add this constant at the top of the class (after the existing XML_PATH constants):
+
+```php
+    private const LOCALE_LANGUAGE_MAP = [
+        'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
+        'ca' => 'Catalan', 'cs' => 'Czech', 'cy' => 'Welsh', 'da' => 'Danish',
+        'de' => 'German', 'el' => 'Greek', 'en' => 'English', 'es' => 'Spanish',
+        'et' => 'Estonian', 'fa' => 'Persian', 'fi' => 'Finnish', 'fr' => 'French',
+        'gl' => 'Galician', 'he' => 'Hebrew', 'hi' => 'Hindi', 'hr' => 'Croatian',
+        'hu' => 'Hungarian', 'id' => 'Indonesian', 'it' => 'Italian', 'ja' => 'Japanese',
+        'ka' => 'Georgian', 'ko' => 'Korean', 'lt' => 'Lithuanian', 'lv' => 'Latvian',
+        'mk' => 'Macedonian', 'ms' => 'Malay', 'nb' => 'Norwegian', 'nl' => 'Dutch',
+        'pl' => 'Polish', 'pt' => 'Portuguese', 'ro' => 'Romanian', 'ru' => 'Russian',
+        'sk' => 'Slovak', 'sl' => 'Slovenian', 'sq' => 'Albanian', 'sr' => 'Serbian',
+        'sv' => 'Swedish', 'th' => 'Thai', 'tr' => 'Turkish', 'uk' => 'Ukrainian',
+        'vi' => 'Vietnamese', 'zh' => 'Chinese',
+    ];
+```
+
+Replace the existing `getSystemPrompt()` method:
+
+```php
+    public function getSystemPrompt(): string
+    {
+        $basePrompt = (string)$this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        if ($locale) {
+            $langCode = substr($locale, 0, 2);
+            $language = self::LOCALE_LANGUAGE_MAP[$langCode] ?? null;
+            if ($language && $langCode !== 'en') {
+                $basePrompt = 'Respond in ' . $language . '. ' . $basePrompt;
+            }
+        }
+
+        return $basePrompt;
+    }
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "feat: locale-aware system prompt prepends language instruction (#12)"
+```
+
+---
+
+### Task 7: Create enrichment log DB schema
+
+**Files:**
+- Create: `etc/db_schema.xml`
+- Create: `etc/db_schema_whitelist.json`
+
+**Step 1: Create the declarative schema**
+
+Create file `etc/db_schema.xml`:
+
+```xml
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="mageos_catalogai_enrichment_log" resource="default" engine="innodb"
+           comment="AI Enrichment Status Log">
+        <column xsi:type="int" name="log_id" unsigned="true" nullable="false" identity="true"
+                comment="Log ID"/>
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false"
+                comment="Product Entity ID"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Attribute Code"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" default="0"
+                comment="Store ID"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="32" default="generated"
+                comment="Enrichment Status"/>
+        <column xsi:type="timestamp" name="generated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Generation Timestamp"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Last Updated"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="log_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE">
+            <column name="entity_id"/>
+            <column name="attribute_code"/>
+            <column name="store_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_STATUS" indexType="btree">
+            <column name="status"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID" indexType="btree">
+            <column name="entity_id"/>
+        </index>
+    </table>
+</schema>
+```
+
+**Step 2: Generate the whitelist**
+
+Run from Magento root (inside Warden):
+
+```bash
+warden env exec php-fpm bin/magento setup:db-declaration:generate-whitelist --module-name=MageOS_CatalogDataAI
+```
+
+This creates `etc/db_schema_whitelist.json`. If running outside Warden is not possible, create it manually:
+
+```json
+{
+    "mageos_catalogai_enrichment_log": {
+        "column": {
+            "log_id": true,
+            "entity_id": true,
+            "attribute_code": true,
+            "store_id": true,
+            "status": true,
+            "generated_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+        }
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add etc/db_schema.xml etc/db_schema_whitelist.json
+git commit -m "feat: add enrichment log DB table schema (#48)"
+```
+
+---
+
+### Task 8: Create EnrichmentLog model and resource model
+
+**Files:**
+- Create: `Model/EnrichmentLog.php`
+- Create: `Model/ResourceModel/EnrichmentLog.php`
+- Create: `Model/ResourceModel/EnrichmentLog/Collection.php`
+
+**Step 1: Create the resource model**
+
+Create file `Model/ResourceModel/EnrichmentLog.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class EnrichmentLog extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_enrichment_log', 'log_id');
+    }
+}
+```
+
+**Step 2: Create the model**
+
+Create file `Model/EnrichmentLog.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class EnrichmentLog extends AbstractModel
+{
+    public const STATUS_GENERATED = 'generated';
+    public const STATUS_PENDING_REVIEW = 'pending_review';
+    public const STATUS_MODIFIED = 'modified';
+
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLogResource::class);
+    }
+}
+```
+
+**Step 3: Create the collection**
+
+Create file `Model/ResourceModel/EnrichmentLog/Collection.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct(): void
+    {
+        $this->_init(EnrichmentLog::class, EnrichmentLogResource::class);
+    }
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add Model/EnrichmentLog.php Model/ResourceModel/EnrichmentLog.php Model/ResourceModel/EnrichmentLog/Collection.php
+git commit -m "feat: add EnrichmentLog model, resource model, and collection (#48)"
+```
+
+---
+
+### Task 9: Create EnrichmentLogger service
+
+**Files:**
+- Create: `Model/Product/EnrichmentLogger.php`
+- Test: `Test/Unit/Model/Product/EnrichmentLoggerTest.php`
+
+**Step 1: Write the test**
+
+Create file `Test/Unit/Model/Product/EnrichmentLoggerTest.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class EnrichmentLoggerTest extends TestCase
+{
+    public function test_log_creates_new_entry_when_none_exists(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($this->createConfiguredMock(
+            EnrichmentLog::class,
+            ['getId' => null]
+        ));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $newLog = $this->createMock(EnrichmentLog::class);
+        $newLog->expects($this->once())->method('setData')->with($this->callback(
+            fn(array $data) => $data['entity_id'] === 42
+                && $data['attribute_code'] === 'description'
+                && $data['store_id'] === 1
+                && $data['status'] === EnrichmentLog::STATUS_GENERATED
+        ));
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $logFactory->method('create')->willReturn($newLog);
+
+        $resource = $this->createMock(EnrichmentLogResource::class);
+        $resource->expects($this->once())->method('save')->with($newLog);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $logger->log(42, 'description', 1);
+    }
+}
+```
+
+**Step 2: Create the service**
+
+Create file `Model/Product/EnrichmentLogger.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class EnrichmentLogger
+{
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogFactory $logFactory,
+        private readonly EnrichmentLogResource $resource
+    ) {
+    }
+
+    public function log(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId()) {
+            $existing->setData('status', EnrichmentLog::STATUS_GENERATED);
+            $this->resource->save($existing);
+        } else {
+            $log = $this->logFactory->create();
+            $log->setData([
+                'entity_id' => $entityId,
+                'attribute_code' => $attributeCode,
+                'store_id' => $storeId,
+                'status' => EnrichmentLog::STATUS_GENERATED,
+            ]);
+            $this->resource->save($log);
+        }
+    }
+
+    public function markModified(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId() && $existing->getData('status') !== EnrichmentLog::STATUS_MODIFIED) {
+            $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
+            $this->resource->save($existing);
+        }
+    }
+
+    public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        return $existing->getId() ? $existing->getData('status') : null;
+    }
+
+    public function getStatusesForProduct(int $entityId, int $storeId): array
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        $statuses = [];
+        foreach ($collection as $item) {
+            $statuses[$item->getData('attribute_code')] = $item->getData('status');
+        }
+
+        return $statuses;
+    }
+
+    private function find(int $entityId, string $attributeCode, int $storeId): EnrichmentLog
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getFirstItem();
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Product/EnrichmentLogger.php Test/Unit/Model/Product/EnrichmentLoggerTest.php
+git commit -m "feat: add EnrichmentLogger service for tracking AI-generated attributes (#48)"
+```
+
+---
+
+### Task 10: Wire EnrichmentLogger into Enricher
+
+**Files:**
+- Modify: `Model/Product/Enricher.php`
+
+**Step 1: Add EnrichmentLogger to Enricher constructor and log after enrichment**
+
+In `Model/Product/Enricher.php`:
+
+Add the import:
+```php
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+```
+
+Update the constructor to add the logger:
+```php
+    public function __construct(
+        private readonly Factory $clientFactory,
+        private readonly Config $config,
+        private readonly EnrichmentLogger $enrichmentLogger
+    ) {
+    }
+```
+
+In the `enrichAttribute` method, after the line `$product->setData($attributeCode, $result->message?->content);` (inside the `if($result = ...)` block), add:
+
+```php
+                $this->enrichmentLogger->log(
+                    (int)$product->getId(),
+                    $attributeCode,
+                    (int)$product->getStoreId()
+                );
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Enricher.php
+git commit -m "feat: Enricher logs enrichment status after successful AI generation (#48)"
+```
+
+---
+
+### Task 11: Detect manual edits in SaveBefore observer
+
+**Files:**
+- Modify: `Observer/Product/SaveBefore.php`
+
+**Step 1: Add manual edit detection**
+
+Replace `Observer/Product/SaveBefore.php` with:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Observer\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class SaveBefore implements ObserverInterface
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly Enricher $enricher,
+        private readonly EnrichmentLogger $enrichmentLogger
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        /** @var Product $product */
+        $product = $observer->getProduct();
+
+        if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
+            $this->enricher->execute($product);
+            return;
+        }
+
+        // Detect manual edits to enriched attributes on existing products
+        if (!$product->isObjectNew() && $product->getId()) {
+            $this->detectManualEdits($product);
+        }
+    }
+
+    private function detectManualEdits(Product $product): void
+    {
+        $storeId = (int)$product->getStoreId();
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            if (!$product->dataHasChangedFor($attributeCode)) {
+                continue;
+            }
+
+            $this->enrichmentLogger->markModified(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId
+            );
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Observer/Product/SaveBefore.php
+git commit -m "feat: detect manual edits to enriched attributes, mark as modified (#48)"
+```
+
+---
+
+### Task 12: Add enrichment status UI modifier for product edit form
+
+**Files:**
+- Create: `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php`
+- Modify: `etc/adminhtml/di.xml` (create if not exists)
+
+**Step 1: Create the UI modifier**
+
+Create file `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
+use Magento\Framework\Stdlib\ArrayManager;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+
+class EnrichmentStatus extends AbstractModifier
+{
+    private const STATUS_LABELS = [
+        'generated' => 'AI Generated',
+        'pending_review' => 'Pending Review',
+        'modified' => 'AI Generated (Modified)',
+    ];
+
+    public function __construct(
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly Config $config,
+        private readonly ArrayManager $arrayManager
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $enrichableAttributes = array_keys($this->config->getEnrichableAttributes());
+
+        foreach ($enrichableAttributes as $attributeCode) {
+            $containerPath = $this->arrayManager->findPath(
+                $attributeCode,
+                $meta,
+                null,
+                'children'
+            );
+
+            if ($containerPath) {
+                $meta = $this->arrayManager->merge(
+                    $containerPath . '/arguments/data/config',
+                    $meta,
+                    [
+                        'additionalClasses' => 'mageos-catalogai-enriched-field',
+                    ]
+                );
+            }
+        }
+
+        return $meta;
+    }
+}
+```
+
+**Step 2: Register the modifier in adminhtml di.xml**
+
+Create file `etc/adminhtml/di.xml`:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="mageos_catalogai_enrichment_status" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus</item>
+                    <item name="sortOrder" xsi:type="number">200</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>
+```
+
+**Step 3: Commit**
+
+```bash
+git add Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php etc/adminhtml/di.xml
+git commit -m "feat: add enrichment status UI modifier for product edit form (#48)"
+```
+
+---
+
+### Task 13: Update module.xml sequence
+
+**Files:**
+- Modify: `etc/module.xml`
+
+**Step 1: Add Magento_Store to the module sequence**
+
+The module now depends on store scope resolution. In `etc/module.xml`, add `Magento_Store` to the sequence:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="MageOS_CatalogDataAI">
+        <sequence>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
+</config>
+```
+
+**Step 2: Commit**
+
+```bash
+git add etc/module.xml
+git commit -m "feat: add Magento_Store to module sequence (#12)"
+```
+
+---
+
+### Task 14: Smoke test — setup:upgrade and di:compile
+
+**Step 1: Run Magento setup commands**
+
+From the Magento root (inside Warden):
+
+```bash
+warden env exec php-fpm bin/magento setup:upgrade
+warden env exec php-fpm bin/magento setup:di:compile
+```
+
+Both should complete without errors.
+
+**Step 2: Verify the DB table was created**
+
+```bash
+warden env exec php-fpm bin/magento db:query "DESCRIBE mageos_catalogai_enrichment_log"
+```
+
+Expected: table with columns `log_id`, `entity_id`, `attribute_code`, `store_id`, `status`, `generated_at`, `updated_at`.
+
+**Step 3: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+Expected: All tests pass.
+
+**Step 4: Final commit (if any adjustments)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 2"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| Modify | `Api/RequestInterface.php` |
+| Modify | `Model/Product/Request.php` |
+| Modify | `Model/Product/Publisher.php` |
+| Modify | `Model/Product/Consumer.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Modify | `Model/Config.php` |
+| Modify | `Observer/Product/SaveBefore.php` |
+| Modify | `Observer/Product/SaveAfter.php` |
+| Modify | `Controller/Adminhtml/Product/MassEnrich.php` |
+| Modify | `etc/module.xml` |
+| Modify | `Test/Unit/Model/ConfigTest.php` |
+| Create | `etc/db_schema.xml` |
+| Create | `etc/db_schema_whitelist.json` |
+| Create | `etc/adminhtml/di.xml` |
+| Create | `Model/EnrichmentLog.php` |
+| Create | `Model/ResourceModel/EnrichmentLog.php` |
+| Create | `Model/ResourceModel/EnrichmentLog/Collection.php` |
+| Create | `Model/Product/EnrichmentLogger.php` |
+| Create | `Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php` |
+| Create | `Test/Unit/Model/Product/RequestTest.php` |
+| Create | `Test/Unit/Model/Product/EnrichmentLoggerTest.php` |

--- a/docs/plans/2026-04-14-phase3-implementation.md
+++ b/docs/plans/2026-04-14-phase3-implementation.md
@@ -1,0 +1,2121 @@
+# Phase 3: Prompt Rules Engine + Config Migration — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move all module config from `catalog_ai/` to `ai_integration/catalog_data_ai/` under the Services tab (coordinating with the translation module), and add a prompt rules engine that lets admins define different prompts per attribute based on product conditions, store scope, and priority.
+
+**Architecture:** Config migration is a straightforward path rename across system.xml, config.xml, Config.php constants, di.xml, and a data patch. The rules engine uses Magento's `Rule` framework for conditions (same as catalog price rules), stores rules in a new `mageos_catalogai_prompt_rule` DB table, and provides an admin grid/form for CRUD. A `PromptResolver` service is injected into the Enricher to resolve the highest-priority matching rule for a given product/attribute/store, falling back to the default dynamic rows config from Phase 1. A preview/test controller lets admins test a rule against a specific SKU.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, Magento Rule Framework (`Magento\Rule`), UI Components (admin grid/form), PHPUnit 9.5
+
+---
+
+## Part A: Config Migration (#43)
+
+### Task 1: Update system.xml — move to ai_integration section
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml`
+
+**Step 1: Replace the entire file**
+
+Move the section from `catalog_ai` (under Catalog tab) to `ai_integration` (under Services tab). Change the section ID, tab, and config path prefix. The group IDs and field IDs stay the same — only the section wrapper changes.
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <tab id="ai_services" translate="label" sortOrder="500">
+            <label>AI Services</label>
+        </tab>
+        <section id="ai_integration_enrichment" translate="label" type="text" sortOrder="10" showInDefault="1">
+            <class>separator-top</class>
+            <label>Data Enrichment</label>
+            <tab>ai_services</tab>
+            <resource>MageOS_CatalogDataAI::config</resource>
+            <group id="settings" translate="label" sortOrder="10" showInDefault="1">
+                <label>Settings</label>
+                <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
+                    <label>Enabled</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="async" translate="label" type="select" sortOrder="20" showInDefault="1" canRestore="1">
+                    <label>Asynchronous enrichment</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="openai_organization_id" translate="label comment" sortOrder="25" showInDefault="1" canRestore="1">
+                    <label>OpenAI Organization ID</label>
+                </field>
+                <field id="openai_key" translate="label comment" type="obscure" sortOrder="30" showInDefault="1" canRestore="1">
+                    <label>OpenAI API key</label>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                </field>
+                <field id="openai_project_id" translate="label" sortOrder="35" showInDefault="1" canRestore="1">
+                    <label>OpenAI Project ID</label>
+                </field>
+                <field id="openai_model" translate="label comment" type="select" sortOrder="40" showInDefault="1" canRestore="1">
+                    <label>OpenAI API Model</label>
+                    <source_model>MageOS\CatalogDataAI\Model\Config\Source\OpenAIModel</source_model>
+                    <comment>Insert API key and organization ID and save to see options. Refer to the documentation to understand which model you should select: https://platform.openai.com/docs/models/overview</comment>
+                </field>
+                <field id="openai_max_tokens" translate="label comment" type="text" sortOrder="45" showInDefault="1" canRestore="1">
+                    <label>OpenAI API Max Tokens</label>
+                </field>
+            </group>
+            <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
+                <label>Default Product Prompts</label>
+                <comment>
+                    <![CDATA[Default prompts used when no matching prompt rule exists. Use {{product_attribute_code}} (e.g. {{name}} for product name) as a placeholder.
+                    <br />
+                    To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
+                </comment>
+                <field id="attribute_prompts" translate="label" sortOrder="10" showInDefault="1" showInStore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\ProductAttributes</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
+                </field>
+            </group>
+            <group id="advanced" translate="label" sortOrder="30" showInDefault="1">
+                <label>Advanced Settings</label>
+                <field id="system_prompt" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
+                    <label>System Prompt</label>
+                    <comment><![CDATA[Instructions sent to the AI model as the developer/system role. Defines the AI's behavior.]]></comment>
+                </field>
+                <field id="temperature" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
+                    <label>Temperature</label>
+                    <comment><![CDATA[Controls randomness. 0.0 = deterministic, 1.0 = creative. Default: 0]]></comment>
+                </field>
+                <field id="frequency_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
+                    <label>Frequency Penalty</label>
+                    <comment><![CDATA[Reduces repetition of token sequences. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+                <field id="presence_penalty" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
+                    <label>Presence Penalty</label>
+                    <comment><![CDATA[Encourages new topics. Range: -2.0 to 2.0. Default: 0]]></comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>
+```
+
+Key changes:
+- New `ai_services` tab
+- Section ID: `catalog_ai` → `ai_integration_enrichment`
+- Tab: `catalog` → `ai_services`
+- Resource: `Magento_Catalog::config_catalog_ai` → `MageOS_CatalogDataAI::config`
+- Product group label: "Product Fields Auto-Generation" → "Default Product Prompts" (clarifies relationship with rules engine)
+
+**Step 2: Commit**
+
+```bash
+git add etc/adminhtml/system.xml
+git commit -m "feat: move config to AI Services tab (#43)"
+```
+
+---
+
+### Task 2: Update config.xml defaults to new paths
+
+**Files:**
+- Modify: `etc/config.xml`
+
+**Step 1: Replace the entire file**
+
+Change the root config path from `<catalog_ai>` to `<ai_integration_enrichment>`:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <ai_integration_enrichment>
+            <settings>
+                <openai_organization_id />
+                <openai_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+                <openai_project_id />
+                <openai_model>gpt-4o</openai_model>
+                <openai_max_tokens>1000</openai_max_tokens>
+            </settings>
+            <product>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute>short_description</attribute>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                        <enabled>1</enabled>
+                    </short_description>
+                    <description>
+                        <attribute>description</attribute>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                        <enabled>1</enabled>
+                    </description>
+                    <meta_title>
+                        <attribute>meta_title</attribute>
+                        <prompt>write a concise SEO meta title for {{name}}, under 60 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_title>
+                    <meta_keyword>
+                        <attribute>meta_keyword</attribute>
+                        <prompt>generate comma-separated SEO keywords for {{name}}, max 10 keywords</prompt>
+                        <enabled>1</enabled>
+                    </meta_keyword>
+                    <meta_description>
+                        <attribute>meta_description</attribute>
+                        <prompt>write an SEO meta description for {{name}}, under 160 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_description>
+                </attribute_prompts>
+            </product>
+            <advanced>
+                <system_prompt>Be a content generator, just reply with the content, skip all introductions.</system_prompt>
+                <temperature>0</temperature>
+                <frequency_penalty>0</frequency_penalty>
+                <presence_penalty>0</presence_penalty>
+            </advanced>
+        </ai_integration_enrichment>
+    </default>
+</config>
+```
+
+**Step 2: Commit**
+
+```bash
+git add etc/config.xml
+git commit -m "feat: update config.xml defaults to new ai_integration_enrichment path (#43)"
+```
+
+---
+
+### Task 3: Update Config.php constants and ACL
+
+**Files:**
+- Modify: `Model/Config.php`
+- Modify: `etc/acl.xml`
+- Modify: `etc/di.xml`
+
+**Step 1: Update all XML_PATH constants in Config.php**
+
+Replace all `catalog_ai/` prefixes with `ai_integration_enrichment/`:
+
+```php
+    public const XML_PATH_ENRICH_ENABLED = 'ai_integration_enrichment/settings/active';
+    public const XML_PATH_USE_ASYNC = 'ai_integration_enrichment/settings/async';
+    public const XML_PATH_OPENAI_ORGANIZATION_ID = 'ai_integration_enrichment/settings/openai_organization_id';
+    public const XML_PATH_OPENAI_API_KEY = 'ai_integration_enrichment/settings/openai_key';
+    public const XML_PATH_OPENAI_PROJECT_ID = 'ai_integration_enrichment/settings/openai_project_id';
+    public const XML_PATH_OPENAI_API_MODEL = 'ai_integration_enrichment/settings/openai_model';
+    public const XML_PATH_OPENAI_API_MAX_TOKENS = 'ai_integration_enrichment/settings/openai_max_tokens';
+    public const XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT = 'ai_integration_enrichment/advanced/system_prompt';
+    public const XML_PATH_OPENAI_API_ADVANCED_TEMPERATURE = 'ai_integration_enrichment/advanced/temperature';
+    public const XML_PATH_OPENAI_API_ADVANCED_FREQUENCY_PENALTY = 'ai_integration_enrichment/advanced/frequency_penalty';
+    public const XML_PATH_OPENAI_API_ADVANCED_PRESENCE_PENALTY = 'ai_integration_enrichment/advanced/presence_penalty';
+```
+
+Also update the hardcoded path in `getEnrichableAttributes()`:
+
+```php
+        $rows = $this->scopeConfig->getValue(
+            'ai_integration_enrichment/product/attribute_prompts'
+        );
+```
+
+**Step 2: Update acl.xml**
+
+Replace the entire file — use module's own ACL resource instead of piggy-backing on Magento_Catalog:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="MageOS_CatalogDataAI::config" title="AI Data Enrichment" translate="title" />
+                        </resource>
+                    </resource>
+                </resource>
+                <resource id="MageOS_CatalogDataAI::prompt_rules" title="AI Prompt Rules" translate="title" sortOrder="50" />
+            </resource>
+        </resources>
+    </acl>
+</config>
+```
+
+**Step 3: Update di.xml sensitive config paths**
+
+Replace `etc/di.xml`:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="ai_integration_enrichment/settings/openai_organization_id" xsi:type="string">1</item>
+                <item name="ai_integration_enrichment/settings/openai_key" xsi:type="string">1</item>
+                <item name="ai_integration_enrichment/settings/openai_project_id" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
+</config>
+```
+
+**Step 4: Update tests**
+
+In `Test/Unit/Model/ConfigTest.php`, update all `willReturnMap` entries to use the new path prefix. Every occurrence of `'catalog_ai/product/attribute_prompts'` becomes `'ai_integration_enrichment/product/attribute_prompts'`.
+
+**Step 5: Commit**
+
+```bash
+git add Model/Config.php etc/acl.xml etc/di.xml Test/Unit/Model/ConfigTest.php
+git commit -m "feat: update Config paths, ACL, and sensitive config to new section (#43)"
+```
+
+---
+
+### Task 4: Config migration data patch
+
+**Files:**
+- Create: `Setup/Patch/Data/MigrateConfigToAiIntegration.php`
+
+**Step 1: Create the data patch**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Setup\Patch\Data;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class MigrateConfigToAiIntegration implements DataPatchInterface
+{
+    private const PATH_MAP = [
+        'catalog_ai/settings/active' => 'ai_integration_enrichment/settings/active',
+        'catalog_ai/settings/async' => 'ai_integration_enrichment/settings/async',
+        'catalog_ai/settings/openai_organization_id' => 'ai_integration_enrichment/settings/openai_organization_id',
+        'catalog_ai/settings/openai_key' => 'ai_integration_enrichment/settings/openai_key',
+        'catalog_ai/settings/openai_project_id' => 'ai_integration_enrichment/settings/openai_project_id',
+        'catalog_ai/settings/openai_model' => 'ai_integration_enrichment/settings/openai_model',
+        'catalog_ai/settings/openai_max_tokens' => 'ai_integration_enrichment/settings/openai_max_tokens',
+        'catalog_ai/product/attribute_prompts' => 'ai_integration_enrichment/product/attribute_prompts',
+        'catalog_ai/advanced/system_prompt' => 'ai_integration_enrichment/advanced/system_prompt',
+        'catalog_ai/advanced/temperature' => 'ai_integration_enrichment/advanced/temperature',
+        'catalog_ai/advanced/frequency_penalty' => 'ai_integration_enrichment/advanced/frequency_penalty',
+        'catalog_ai/advanced/presence_penalty' => 'ai_integration_enrichment/advanced/presence_penalty',
+    ];
+
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly WriterInterface $configWriter
+    ) {
+    }
+
+    public function apply(): self
+    {
+        foreach (self::PATH_MAP as $oldPath => $newPath) {
+            $value = $this->scopeConfig->getValue($oldPath);
+            if ($value !== null) {
+                $this->configWriter->save($newPath, $value);
+                $this->configWriter->delete($oldPath);
+            }
+        }
+
+        return $this;
+    }
+
+    public static function getDependencies(): array
+    {
+        return [MigrateProductPromptsToDynamicRows::class];
+    }
+
+    public function getAliases(): array
+    {
+        return [];
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Setup/Patch/Data/MigrateConfigToAiIntegration.php
+git commit -m "feat: add data patch to migrate config from catalog_ai to ai_integration_enrichment (#43)"
+```
+
+---
+
+## Part B: Prompt Rules Engine (#32)
+
+### Task 5: Add prompt_rule DB table schema
+
+**Files:**
+- Modify: `etc/db_schema.xml`
+- Modify: `etc/db_schema_whitelist.json`
+
+**Step 1: Add the rules table to db_schema.xml**
+
+Add this table after the existing `mageos_catalogai_enrichment_log` table:
+
+```xml
+    <table name="mageos_catalogai_prompt_rule" resource="default" engine="innodb"
+           comment="AI Prompt Rules">
+        <column xsi:type="int" name="rule_id" unsigned="true" nullable="false" identity="true"
+                comment="Rule ID"/>
+        <column xsi:type="varchar" name="name" nullable="false" length="255"
+                comment="Rule Name"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Target Attribute Code"/>
+        <column xsi:type="text" name="store_ids" nullable="false"
+                comment="Store IDs (comma-separated, 0 = all)"/>
+        <column xsi:type="text" name="conditions_serialized" nullable="true"
+                comment="Serialized Product Conditions"/>
+        <column xsi:type="text" name="prompt" nullable="false"
+                comment="Prompt Template"/>
+        <column xsi:type="int" name="priority" unsigned="false" nullable="false" default="0"
+                comment="Priority (highest wins)"/>
+        <column xsi:type="boolean" name="is_active" nullable="false" default="true"
+                comment="Is Active"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="rule_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE" indexType="btree">
+            <column name="attribute_code"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE" indexType="btree">
+            <column name="is_active"/>
+        </index>
+    </table>
+```
+
+**Step 2: Update the whitelist JSON**
+
+Add the new table to `etc/db_schema_whitelist.json`:
+
+```json
+{
+    "mageos_catalogai_enrichment_log": {
+        "column": {
+            "log_id": true,
+            "entity_id": true,
+            "attribute_code": true,
+            "store_id": true,
+            "status": true,
+            "generated_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+        }
+    },
+    "mageos_catalogai_prompt_rule": {
+        "column": {
+            "rule_id": true,
+            "name": true,
+            "attribute_code": true,
+            "store_ids": true,
+            "conditions_serialized": true,
+            "prompt": true,
+            "priority": true,
+            "is_active": true,
+            "created_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE": true,
+            "MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE": true
+        }
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add etc/db_schema.xml etc/db_schema_whitelist.json
+git commit -m "feat: add prompt_rule DB table schema (#32)"
+```
+
+---
+
+### Task 6: Create PromptRule model, resource model, and collection
+
+**Files:**
+- Create: `Model/PromptRule.php`
+- Create: `Model/ResourceModel/PromptRule.php`
+- Create: `Model/ResourceModel/PromptRule/Collection.php`
+- Create: `Api/Data/PromptRuleInterface.php`
+
+**Step 1: Create the interface**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api\Data;
+
+interface PromptRuleInterface
+{
+    public const RULE_ID = 'rule_id';
+    public const NAME = 'name';
+    public const ATTRIBUTE_CODE = 'attribute_code';
+    public const STORE_IDS = 'store_ids';
+    public const CONDITIONS_SERIALIZED = 'conditions_serialized';
+    public const PROMPT = 'prompt';
+    public const PRIORITY = 'priority';
+    public const IS_ACTIVE = 'is_active';
+
+    public function getRuleId(): ?int;
+    public function getName(): string;
+    public function getAttributeCode(): string;
+    public function getStoreIds(): string;
+    public function getConditionsSerialized(): ?string;
+    public function getPrompt(): string;
+    public function getPriority(): int;
+    public function getIsActive(): bool;
+}
+```
+
+**Step 2: Create the model**
+
+The model extends `Magento\Rule\Model\AbstractModel` to get the conditions framework for free:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\CatalogRule\Model\Rule\Condition\Combine;
+use Magento\Rule\Model\AbstractModel;
+use MageOS\CatalogDataAI\Api\Data\PromptRuleInterface;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class PromptRule extends AbstractModel implements PromptRuleInterface
+{
+    protected $_eventPrefix = 'mageos_catalogai_prompt_rule';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRuleResource::class);
+    }
+
+    public function getConditionsInstance(): \Magento\Rule\Model\Condition\Combine
+    {
+        return $this->_conditionFactory->create(Combine::class);
+    }
+
+    public function getActionsInstance(): \Magento\Rule\Model\Action\Collection
+    {
+        return $this->_actionFactory->create(\Magento\Rule\Model\Action\Collection::class);
+    }
+
+    public function getRuleId(): ?int
+    {
+        return $this->getData(self::RULE_ID) ? (int)$this->getData(self::RULE_ID) : null;
+    }
+
+    public function getName(): string
+    {
+        return (string)$this->getData(self::NAME);
+    }
+
+    public function getAttributeCode(): string
+    {
+        return (string)$this->getData(self::ATTRIBUTE_CODE);
+    }
+
+    public function getStoreIds(): string
+    {
+        return (string)$this->getData(self::STORE_IDS);
+    }
+
+    public function getConditionsSerialized(): ?string
+    {
+        return $this->getData(self::CONDITIONS_SERIALIZED);
+    }
+
+    public function getPrompt(): string
+    {
+        return (string)$this->getData(self::PROMPT);
+    }
+
+    public function getPriority(): int
+    {
+        return (int)$this->getData(self::PRIORITY);
+    }
+
+    public function getIsActive(): bool
+    {
+        return (bool)$this->getData(self::IS_ACTIVE);
+    }
+
+    public function matchesProduct(\Magento\Catalog\Model\Product $product): bool
+    {
+        return $this->getConditions()->validate($product);
+    }
+
+    public function matchesStore(int $storeId): bool
+    {
+        $storeIds = $this->getStoreIds();
+        if ($storeIds === '' || $storeIds === '0') {
+            return true;
+        }
+        $ids = array_map('intval', explode(',', $storeIds));
+        return in_array(0, $ids, true) || in_array($storeId, $ids, true);
+    }
+}
+```
+
+**Step 3: Create the resource model**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class PromptRule extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_prompt_rule', 'rule_id');
+    }
+}
+```
+
+**Step 4: Create the collection**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Collection extends AbstractCollection
+{
+    protected $_idFieldName = 'rule_id';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRule::class, PromptRuleResource::class);
+    }
+}
+```
+
+**Step 5: Commit**
+
+```bash
+git add Api/Data/PromptRuleInterface.php Model/PromptRule.php Model/ResourceModel/PromptRule.php Model/ResourceModel/PromptRule/Collection.php
+git commit -m "feat: add PromptRule model with conditions support (#32)"
+```
+
+---
+
+### Task 7: Create PromptResolver service
+
+**Files:**
+- Create: `Model/Product/PromptResolver.php`
+- Test: `Test/Unit/Model/Product/PromptResolverTest.php`
+
+This is the core logic — given a product, attribute, and store, find the highest-priority matching rule. Fall back to the default config prompt if no rule matches.
+
+**Step 1: Write the test**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+use Magento\Catalog\Model\Product;
+use PHPUnit\Framework\TestCase;
+
+final class PromptResolverTest extends TestCase
+{
+    public function test_returns_highest_priority_matching_rule_prompt(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $lowRule = $this->createMock(PromptRule::class);
+        $lowRule->method('getIsActive')->willReturn(true);
+        $lowRule->method('getPriority')->willReturn(10);
+        $lowRule->method('getPrompt')->willReturn('low priority prompt');
+        $lowRule->method('matchesStore')->willReturn(true);
+        $lowRule->method('matchesProduct')->willReturn(true);
+
+        $highRule = $this->createMock(PromptRule::class);
+        $highRule->method('getIsActive')->willReturn(true);
+        $highRule->method('getPriority')->willReturn(50);
+        $highRule->method('getPrompt')->willReturn('high priority prompt');
+        $highRule->method('matchesStore')->willReturn(true);
+        $highRule->method('matchesProduct')->willReturn(true);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([$highRule, $lowRule]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('high priority prompt', $result);
+    }
+
+    public function test_falls_back_to_config_when_no_rule_matches(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+        $config->method('getProductPrompt')
+            ->with('description')
+            ->willReturn('default config prompt');
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('default config prompt', $result);
+    }
+}
+```
+
+**Step 2: Create the service**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Model\Product;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class PromptResolver
+{
+    public function __construct(
+        private readonly CollectionFactory $ruleCollectionFactory,
+        private readonly Config $config
+    ) {
+    }
+
+    public function resolve(string $attributeCode, Product $product): ?string
+    {
+        $storeId = (int)$product->getStoreId();
+
+        $collection = $this->ruleCollectionFactory->create();
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('is_active', 1);
+        $collection->setOrder('priority', 'DESC');
+
+        /** @var PromptRule $rule */
+        foreach ($collection as $rule) {
+            if ($rule->matchesStore($storeId) && $rule->matchesProduct($product)) {
+                return $rule->getPrompt();
+            }
+        }
+
+        return $this->config->getProductPrompt($attributeCode);
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Product/PromptResolver.php Test/Unit/Model/Product/PromptResolverTest.php
+git commit -m "feat: add PromptResolver service with priority-based rule matching (#32)"
+```
+
+---
+
+### Task 8: Wire PromptResolver into Enricher
+
+**Files:**
+- Modify: `Model/Product/Enricher.php`
+- Modify: `Test/Unit/Model/Product/EnricherTest.php`
+
+**Step 1: Add PromptResolver to Enricher**
+
+In `Model/Product/Enricher.php`:
+
+Add import:
+```php
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
+```
+
+Update constructor:
+```php
+    public function __construct(
+        private readonly Factory $clientFactory,
+        private readonly Config $config,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly PromptResolver $promptResolver
+    ) {
+    }
+```
+
+In `enrichAttribute()`, replace the line:
+```php
+        if ($prompt = $this->config->getProductPrompt($attributeCode)) {
+```
+with:
+```php
+        if ($prompt = $this->promptResolver->resolve($attributeCode, $product)) {
+```
+
+**Step 2: Update the EnricherTest**
+
+Add `PromptResolver` mock to both test methods' setup. In the constructor calls, add the fourth parameter:
+
+```php
+        $promptResolver = $this->createMock(PromptResolver::class);
+        $enricher = new Enricher($factory, $config, $logger, $promptResolver);
+```
+
+Add the import:
+```php
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Product/Enricher.php Test/Unit/Model/Product/EnricherTest.php
+git commit -m "feat: Enricher uses PromptResolver for rule-based prompt selection (#32)"
+```
+
+---
+
+### Task 9: Admin grid — controllers, layout, and UI component
+
+**Files:**
+- Create: `Controller/Adminhtml/PromptRule/Index.php`
+- Create: `view/adminhtml/layout/catalogai_promptrule_index.xml`
+- Create: `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml`
+- Modify: `etc/adminhtml/routes.xml` (already exists)
+
+**Step 1: Create the Index controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Prompt Rules'));
+        return $resultPage;
+    }
+}
+```
+
+**Step 2: Create the layout XML**
+
+Create `view/adminhtml/layout/catalogai_promptrule_index.xml`:
+
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_listing"/>
+        </referenceContainer>
+    </body>
+</page>
+```
+
+**Step 3: Create the grid UI component**
+
+Create `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="add">
+                <url path="catalogai/promptrule/new"/>
+                <class>primary</class>
+                <label translate="true">Add New Rule</label>
+            </button>
+        </buttons>
+        <spinner>mageos_catalogai_prompt_rule_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_prompt_rule_listing_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+        <massaction name="listing_massaction">
+            <action name="delete">
+                <settings>
+                    <confirm>
+                        <message translate="true">Delete selected rules?</message>
+                        <title translate="true">Delete</title>
+                    </confirm>
+                    <url path="catalogai/promptrule/massDelete"/>
+                    <type>delete</type>
+                    <label translate="true">Delete</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="mageos_catalogai_prompt_rule_columns">
+        <selectionsColumn name="ids">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="rule_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>asc</sorting>
+            </settings>
+        </column>
+        <column name="name">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Name</label>
+            </settings>
+        </column>
+        <column name="attribute_code">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Attribute</label>
+            </settings>
+        </column>
+        <column name="priority">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Priority</label>
+            </settings>
+        </column>
+        <column name="is_active" component="Magento_Ui/js/grid/columns/select">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Active</label>
+                <dataType>select</dataType>
+                <options class="Magento\Config\Model\Config\Source\Yesno"/>
+            </settings>
+        </column>
+        <column name="updated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Updated</label>
+            </settings>
+        </column>
+        <actionsColumn name="actions" class="MageOS\CatalogDataAI\Ui\Component\Listing\Column\PromptRuleActions">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </actionsColumn>
+    </columns>
+</listing>
+```
+
+**Step 4: Create the actions column class**
+
+Create `Ui/Component/Listing/Column/PromptRuleActions.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class PromptRuleActions extends Column
+{
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        private readonly UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                if (isset($item['rule_id'])) {
+                    $item[$this->getData('name')] = [
+                        'edit' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/edit',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Edit'),
+                        ],
+                        'delete' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/delete',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Delete'),
+                            'confirm' => [
+                                'title' => __('Delete Rule'),
+                                'message' => __('Are you sure you want to delete this rule?'),
+                            ],
+                        ],
+                    ];
+                }
+            }
+        }
+        return $dataSource;
+    }
+}
+```
+
+**Step 5: Register the grid data source in adminhtml di.xml**
+
+In `etc/adminhtml/di.xml`, add the collection provider for the grid data source (append to existing file, inside the `<config>` tag):
+
+```xml
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="mageos_catalogai_prompt_rule_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
+```
+
+**Step 6: Create the grid collection (search result compatible)**
+
+Create `Model/ResourceModel/PromptRule/Grid/Collection.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_prompt_rule',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\PromptRule::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('rule_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}
+```
+
+**Step 7: Add admin menu**
+
+Create `etc/adminhtml/menu.xml`:
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add id="MageOS_CatalogDataAI::prompt_rules"
+             title="AI Prompt Rules"
+             module="MageOS_CatalogDataAI"
+             sortOrder="90"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/promptrule"
+             resource="MageOS_CatalogDataAI::prompt_rules"/>
+    </menu>
+</config>
+```
+
+**Step 8: Commit**
+
+```bash
+git add Controller/Adminhtml/PromptRule/Index.php \
+    view/adminhtml/layout/catalogai_promptrule_index.xml \
+    view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml \
+    Ui/Component/Listing/Column/PromptRuleActions.php \
+    Model/ResourceModel/PromptRule/Grid/Collection.php \
+    etc/adminhtml/di.xml \
+    etc/adminhtml/menu.xml
+git commit -m "feat: add prompt rules admin grid with listing and menu (#32)"
+```
+
+---
+
+### Task 10: Admin form — Edit/New controllers and form UI component
+
+**Files:**
+- Create: `Controller/Adminhtml/PromptRule/Edit.php`
+- Create: `Controller/Adminhtml/PromptRule/NewAction.php`
+- Create: `Controller/Adminhtml/PromptRule/Save.php`
+- Create: `Controller/Adminhtml/PromptRule/Delete.php`
+- Create: `view/adminhtml/layout/catalogai_promptrule_edit.xml`
+- Create: `view/adminhtml/layout/catalogai_promptrule_new.xml`
+- Create: `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml`
+- Create: `Model/PromptRule/DataProvider.php`
+
+**Step 1: Create Edit controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Edit extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $this->resultRedirectFactory->create()->setPath('*/*/');
+            }
+        }
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(
+            $ruleId ? __('Edit Rule: %1', $rule->getName()) : __('New Prompt Rule')
+        );
+
+        return $resultPage;
+    }
+}
+```
+
+**Step 2: Create NewAction controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+
+class NewAction extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function execute()
+    {
+        return $this->resultFactory->create(ResultFactory::TYPE_FORWARD)->forward('edit');
+    }
+}
+```
+
+**Step 3: Create Save controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Save extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $data = $this->getRequest()->getPostValue();
+        $redirect = $this->resultRedirectFactory->create();
+
+        if (!$data) {
+            return $redirect->setPath('*/*/');
+        }
+
+        $ruleId = (int)($data['rule_id'] ?? 0);
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $redirect->setPath('*/*/');
+            }
+        }
+
+        if (isset($data['store_ids']) && is_array($data['store_ids'])) {
+            $data['store_ids'] = implode(',', $data['store_ids']);
+        }
+
+        if (isset($data['rule']['conditions'])) {
+            $rule->loadPost(['conditions' => $data['rule']['conditions']]);
+        }
+
+        $rule->addData($data);
+
+        try {
+            $this->ruleResource->save($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been saved.'));
+
+            if ($this->getRequest()->getParam('back')) {
+                return $redirect->setPath('*/*/edit', ['rule_id' => $rule->getRuleId()]);
+            }
+            return $redirect->setPath('*/*/');
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+            return $redirect->setPath('*/*/edit', ['rule_id' => $ruleId]);
+        }
+    }
+}
+```
+
+**Step 4: Create Delete controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Delete extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $redirect = $this->resultRedirectFactory->create()->setPath('*/*/');
+
+        if (!$ruleId) {
+            $this->messageManager->addErrorMessage(__('Rule ID is required.'));
+            return $redirect;
+        }
+
+        $rule = $this->ruleFactory->create();
+        $this->ruleResource->load($rule, $ruleId);
+
+        if (!$rule->getRuleId()) {
+            $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+            return $redirect;
+        }
+
+        try {
+            $this->ruleResource->delete($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been deleted.'));
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+        }
+
+        return $redirect;
+    }
+}
+```
+
+**Step 5: Create layout files**
+
+`view/adminhtml/layout/catalogai_promptrule_edit.xml`:
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>
+```
+
+`view/adminhtml/layout/catalogai_promptrule_new.xml`:
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>
+```
+
+**Step 6: Create the form DataProvider**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\PromptRule;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\AbstractDataProvider;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class DataProvider extends AbstractDataProvider
+{
+    private array $loadedData = [];
+
+    public function __construct(
+        string $name,
+        string $primaryFieldName,
+        string $requestFieldName,
+        CollectionFactory $collectionFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $collectionFactory->create();
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    public function getData(): array
+    {
+        if (!empty($this->loadedData)) {
+            return $this->loadedData;
+        }
+
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            if ($rule->getRuleId()) {
+                $data = $rule->getData();
+                if (isset($data['store_ids']) && is_string($data['store_ids'])) {
+                    $data['store_ids'] = explode(',', $data['store_ids']);
+                }
+                $this->loadedData[$ruleId] = $data;
+            }
+        }
+
+        return $this->loadedData;
+    }
+}
+```
+
+**Step 7: Create the form UI component**
+
+Create `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Prompt Rule</item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="back">
+                <url path="*/*/"/>
+                <class>back</class>
+                <label translate="true">Back</label>
+            </button>
+            <button name="delete" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\DeleteButton"/>
+            <button name="save" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\SaveButton"/>
+        </buttons>
+        <namespace>mageos_catalogai_prompt_rule_form</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_form_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="catalogai/promptrule/save"/>
+        </settings>
+        <dataProvider class="MageOS\CatalogDataAI\Model\PromptRule\DataProvider" name="mageos_catalogai_prompt_rule_form_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general">
+        <settings>
+            <label translate="true">Rule Information</label>
+        </settings>
+        <field name="rule_id" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+            </settings>
+        </field>
+        <field name="name" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Rule Name</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="is_active" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="default" xsi:type="number">1</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Active</label>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="number">0</map>
+                            <map name="true" xsi:type="number">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+        <field name="attribute_code" formElement="select">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Target Attribute</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+            <formElements>
+                <select>
+                    <settings>
+                        <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichableAttributes"/>
+                    </settings>
+                </select>
+            </formElements>
+        </field>
+        <field name="store_ids" formElement="multiselect">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Store Views</label>
+                <tooltip>
+                    <description translate="true">Select store views this rule applies to. Leave empty or select "All Store Views" for all stores.</description>
+                </tooltip>
+            </settings>
+            <formElements>
+                <multiselect>
+                    <settings>
+                        <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
+                    </settings>
+                </multiselect>
+            </formElements>
+        </field>
+        <field name="priority" formElement="input">
+            <settings>
+                <dataType>number</dataType>
+                <label translate="true">Priority</label>
+                <notice translate="true">Higher value = higher priority. When multiple rules match, the one with the highest priority wins.</notice>
+                <validation>
+                    <rule name="validate-digits" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+    <fieldset name="prompt_fieldset">
+        <settings>
+            <label translate="true">Prompt</label>
+        </settings>
+        <field name="prompt" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Prompt Template</label>
+                <notice translate="true">Use {{attribute_code}} placeholders for product data (e.g. {{name}}, {{price}}).</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+</form>
+```
+
+**Step 8: Create the EnrichableAttributes source model**
+
+Create `Model/Config/Source/EnrichableAttributes.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class EnrichableAttributes implements OptionSourceInterface
+{
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+    }
+
+    public function toOptionArray(): array
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+            ->create();
+
+        $attributes = $this->attributeRepository->getList($searchCriteria);
+
+        $options = [['value' => '', 'label' => __('-- Please Select --')]];
+        foreach ($attributes->getItems() as $attribute) {
+            $options[] = [
+                'value' => $attribute->getAttributeCode(),
+                'label' => ($attribute->getDefaultFrontendLabel() ?? $attribute->getAttributeCode()),
+            ];
+        }
+
+        usort($options, fn($a, $b) => strcmp((string)$a['label'], (string)$b['label']));
+
+        return $options;
+    }
+}
+```
+
+**Step 9: Create Save/Delete button blocks**
+
+Create `Block/Adminhtml/PromptRule/Edit/SaveButton.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class SaveButton implements ButtonProviderInterface
+{
+    public function getButtonData(): array
+    {
+        return [
+            'label' => __('Save Rule'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+    }
+}
+```
+
+Create `Block/Adminhtml/PromptRule/Edit/DeleteButton.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class DeleteButton implements ButtonProviderInterface
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly UrlInterface $urlBuilder
+    ) {
+    }
+
+    public function getButtonData(): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if (!$ruleId) {
+            return [];
+        }
+
+        return [
+            'label' => __('Delete Rule'),
+            'class' => 'delete',
+            'on_click' => sprintf(
+                "deleteConfirm('%s', '%s', {data: {}})",
+                __('Are you sure you want to delete this rule?'),
+                $this->urlBuilder->getUrl('*/*/delete', ['rule_id' => $ruleId])
+            ),
+            'sort_order' => 20,
+        ];
+    }
+}
+```
+
+**Step 10: Commit**
+
+```bash
+git add Controller/Adminhtml/PromptRule/Edit.php \
+    Controller/Adminhtml/PromptRule/NewAction.php \
+    Controller/Adminhtml/PromptRule/Save.php \
+    Controller/Adminhtml/PromptRule/Delete.php \
+    view/adminhtml/layout/catalogai_promptrule_edit.xml \
+    view/adminhtml/layout/catalogai_promptrule_new.xml \
+    view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml \
+    Model/PromptRule/DataProvider.php \
+    Model/Config/Source/EnrichableAttributes.php \
+    Block/Adminhtml/PromptRule/Edit/SaveButton.php \
+    Block/Adminhtml/PromptRule/Edit/DeleteButton.php
+git commit -m "feat: add prompt rule edit form with CRUD controllers (#32)"
+```
+
+---
+
+### Task 11: Add conditions fieldset via form modifier
+
+**Files:**
+- Create: `Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php`
+- Modify: `etc/adminhtml/di.xml`
+
+The Magento Rule conditions widget requires a special UI modifier to render conditions HTML within the UI component form. This follows the same pattern as `Magento_CatalogRule`.
+
+**Step 1: Create the conditions modifier**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Rule\Model\Condition\AbstractCondition;
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Conditions implements ModifierInterface
+{
+    public function __construct(
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId && isset($data[$ruleId])) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            $conditions = $rule->getConditions()->asArray();
+            $data[$ruleId]['rule']['conditions'] = $this->convertConditions($conditions);
+        }
+
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $meta['conditions_fieldset'] = [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Conditions'),
+                        'componentType' => 'fieldset',
+                        'collapsible' => true,
+                        'sortOrder' => 20,
+                    ],
+                ],
+            ],
+            'children' => [
+                'conditions_notice' => [
+                    'arguments' => [
+                        'data' => [
+                            'config' => [
+                                'componentType' => 'container',
+                                'component' => 'Magento_Ui/js/form/components/html',
+                                'content' => (string)__(
+                                    'Define product conditions that must match for this rule to apply. '
+                                    . 'If no conditions are set, the rule applies to all products.'
+                                ),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $meta;
+    }
+
+    private function convertConditions(array $conditions): array
+    {
+        $result = [];
+        if (isset($conditions['type'])) {
+            $result['type'] = $conditions['type'];
+            $result['attribute'] = $conditions['attribute'] ?? '';
+            $result['operator'] = $conditions['operator'] ?? '';
+            $result['value'] = $conditions['value'] ?? '';
+            $result['aggregator'] = $conditions['aggregator'] ?? 'all';
+            if (isset($conditions['conditions'])) {
+                foreach ($conditions['conditions'] as $key => $condition) {
+                    $result['conditions'][$key] = $this->convertConditions($condition);
+                }
+            }
+        }
+        return $result;
+    }
+}
+```
+
+**Step 2: Register the modifier in adminhtml di.xml**
+
+Add to `etc/adminhtml/di.xml`:
+
+```xml
+    <virtualType name="MageOS\CatalogDataAI\PromptRule\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="conditions" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier\Conditions</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+```
+
+**Step 3: Commit**
+
+```bash
+git add Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php etc/adminhtml/di.xml
+git commit -m "feat: add conditions fieldset modifier for prompt rule form (#32)"
+```
+
+---
+
+### Task 12: Add preview/test AJAX controller
+
+**Files:**
+- Create: `Controller/Adminhtml/PromptRule/Preview.php`
+
+**Step 1: Create the preview controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\JsonFactory;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+
+class Preview extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $jsonFactory,
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly Enricher $enricher
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $result = $this->jsonFactory->create();
+        $sku = $this->getRequest()->getParam('sku');
+        $prompt = $this->getRequest()->getParam('prompt');
+
+        if (!$sku || !$prompt) {
+            return $result->setData([
+                'success' => false,
+                'message' => 'SKU and prompt are required.',
+            ]);
+        }
+
+        try {
+            $product = $this->productRepository->get($sku);
+            $resolvedPrompt = $this->enricher->parsePrompt($prompt, $product);
+
+            return $result->setData([
+                'success' => true,
+                'resolved_prompt' => $resolvedPrompt,
+                'product_name' => $product->getName(),
+            ]);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => sprintf('Product with SKU "%s" not found.', $sku),
+            ]);
+        } catch (\Exception $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/PromptRule/Preview.php
+git commit -m "feat: add preview/test controller for prompt rules (#32)"
+```
+
+---
+
+### Task 13: Add MassDelete controller
+
+**Files:**
+- Create: `Controller/Adminhtml/PromptRule/MassDelete.php`
+
+**Step 1: Create the mass delete controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class MassDelete extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $deleted = 0;
+
+        foreach ($collection as $rule) {
+            $this->ruleResource->delete($rule);
+            $deleted++;
+        }
+
+        $this->messageManager->addSuccessMessage(__('A total of %1 rule(s) have been deleted.', $deleted));
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/PromptRule/MassDelete.php
+git commit -m "feat: add mass delete controller for prompt rules (#32)"
+```
+
+---
+
+### Task 14: Smoke test
+
+**Step 1: Run Magento setup commands (inside Warden)**
+
+```bash
+warden env exec php-fpm bin/magento setup:upgrade
+warden env exec php-fpm bin/magento setup:di:compile
+```
+
+Both should complete without errors.
+
+**Step 2: Verify the DB table**
+
+Check that `mageos_catalogai_prompt_rule` table was created with correct columns.
+
+**Step 3: Verify admin pages**
+
+1. Navigate to **Catalog > AI Prompt Rules** — grid should load
+2. Click **Add New Rule** — form should render with all fields
+3. Create a test rule: name, attribute, prompt, priority, save — should persist
+4. Navigate to **AI Services > Data Enrichment** — config should render at the new location
+5. Verify old config at Catalog > AI Data Enrichment no longer exists
+
+**Step 4: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+Expected: All tests pass.
+
+**Step 5: Final commit (if adjustments needed)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 3"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| **Config Migration** | |
+| Modify | `etc/adminhtml/system.xml` |
+| Modify | `etc/config.xml` |
+| Modify | `Model/Config.php` |
+| Modify | `etc/acl.xml` |
+| Modify | `etc/di.xml` |
+| Modify | `Test/Unit/Model/ConfigTest.php` |
+| Create | `Setup/Patch/Data/MigrateConfigToAiIntegration.php` |
+| **Rules Engine — Data** | |
+| Modify | `etc/db_schema.xml` |
+| Modify | `etc/db_schema_whitelist.json` |
+| Create | `Api/Data/PromptRuleInterface.php` |
+| Create | `Model/PromptRule.php` |
+| Create | `Model/ResourceModel/PromptRule.php` |
+| Create | `Model/ResourceModel/PromptRule/Collection.php` |
+| Create | `Model/ResourceModel/PromptRule/Grid/Collection.php` |
+| Create | `Model/Product/PromptResolver.php` |
+| Create | `Test/Unit/Model/Product/PromptResolverTest.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Modify | `Test/Unit/Model/Product/EnricherTest.php` |
+| **Rules Engine — Admin UI** | |
+| Create | `etc/adminhtml/menu.xml` |
+| Modify | `etc/adminhtml/di.xml` |
+| Create | `Controller/Adminhtml/PromptRule/Index.php` |
+| Create | `Controller/Adminhtml/PromptRule/Edit.php` |
+| Create | `Controller/Adminhtml/PromptRule/NewAction.php` |
+| Create | `Controller/Adminhtml/PromptRule/Save.php` |
+| Create | `Controller/Adminhtml/PromptRule/Delete.php` |
+| Create | `Controller/Adminhtml/PromptRule/MassDelete.php` |
+| Create | `Controller/Adminhtml/PromptRule/Preview.php` |
+| Create | `Model/PromptRule/DataProvider.php` |
+| Create | `Model/Config/Source/EnrichableAttributes.php` |
+| Create | `Block/Adminhtml/PromptRule/Edit/SaveButton.php` |
+| Create | `Block/Adminhtml/PromptRule/Edit/DeleteButton.php` |
+| Create | `Ui/Component/Listing/Column/PromptRuleActions.php` |
+| Create | `Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php` |
+| Create | `view/adminhtml/layout/catalogai_promptrule_index.xml` |
+| Create | `view/adminhtml/layout/catalogai_promptrule_edit.xml` |
+| Create | `view/adminhtml/layout/catalogai_promptrule_new.xml` |
+| Create | `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml` |
+| Create | `view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml` |

--- a/docs/plans/2026-04-14-phase4-implementation.md
+++ b/docs/plans/2026-04-14-phase4-implementation.md
@@ -1,0 +1,999 @@
+# Phase 4: Review/Approval Workflow — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an admin review grid for AI-generated content with approve/reject/revert actions, a "require review" config toggle that holds content in pending state until approved, and prompt hash-based deduplication to avoid redundant API calls.
+
+**Architecture:** The existing `mageos_catalogai_enrichment_log` table gains new columns: `generated_content`, `original_content`, and `prompt_hash`. The `EnrichmentLogger` is extended to store generated content and original values. When "require review" is enabled, the Enricher writes content to the log but does NOT set it on the product — an admin must approve it via a new review grid. The grid provides approve (writes to product), reject (reverts), and re-generate actions. Before calling OpenAI, the Enricher checks the prompt hash to reuse cached responses.
+
+**Tech Stack:** PHP 8.1+, Magento 2.4.x, UI Components (admin grid), PHPUnit 9.5
+
+---
+
+### Task 1: Add new columns to enrichment_log table
+
+**Files:**
+- Modify: `etc/db_schema.xml`
+- Modify: `etc/db_schema_whitelist.json`
+
+**Step 1: Add columns to the enrichment_log table**
+
+In `etc/db_schema.xml`, add these columns inside the `mageos_catalogai_enrichment_log` table, after the `status` column and before `generated_at`:
+
+```xml
+        <column xsi:type="text" name="generated_content" nullable="true"
+                comment="AI Generated Content"/>
+        <column xsi:type="text" name="original_content" nullable="true"
+                comment="Original Content Before Enrichment"/>
+        <column xsi:type="varchar" name="prompt_hash" nullable="true" length="64"
+                comment="SHA-256 Hash of Resolved Prompt"/>
+```
+
+Add an index for prompt_hash after the existing indexes:
+
+```xml
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_PROMPT_HASH" indexType="btree">
+            <column name="prompt_hash"/>
+        </index>
+```
+
+**Step 2: Update the whitelist**
+
+In `etc/db_schema_whitelist.json`, add to the `mageos_catalogai_enrichment_log.column` object:
+
+```json
+            "generated_content": true,
+            "original_content": true,
+            "prompt_hash": true
+```
+
+And add to the `index` object:
+
+```json
+            "MAGEOS_CATALOGAI_ENRICH_LOG_PROMPT_HASH": true
+```
+
+**Step 3: Commit**
+
+```bash
+git add etc/db_schema.xml etc/db_schema_whitelist.json
+git commit -m "feat: add generated_content, original_content, prompt_hash columns to enrichment log (#28)"
+```
+
+---
+
+### Task 2: Add review mode config toggle
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml`
+- Modify: `etc/config.xml`
+- Modify: `Model/Config.php`
+
+**Step 1: Add the config field to system.xml**
+
+In `etc/adminhtml/system.xml`, inside the `settings` group, add after the `async` field (after line ~20):
+
+```xml
+                <field id="require_review" translate="label comment" type="select" sortOrder="22" showInDefault="1" canRestore="1">
+                    <label>Require Review Before Publish</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[When enabled, AI-generated content is held for review and not written to products until approved.]]></comment>
+                </field>
+```
+
+**Step 2: Add default value to config.xml**
+
+In `etc/config.xml`, inside `<settings>`, add:
+
+```xml
+                <require_review>0</require_review>
+```
+
+**Step 3: Add getter to Config.php**
+
+In `Model/Config.php`, add a constant and method. Add the constant after the existing ones:
+
+```php
+    public const XML_PATH_REQUIRE_REVIEW = 'ai_integration_enrichment/settings/require_review';
+```
+
+Add the method after `isAsync()`:
+
+```php
+    public function requiresReview(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_REQUIRE_REVIEW
+        );
+    }
+```
+
+**Step 4: Commit**
+
+```bash
+git add etc/adminhtml/system.xml etc/config.xml Model/Config.php
+git commit -m "feat: add require_review config toggle (#28)"
+```
+
+---
+
+### Task 3: Expand EnrichmentLog statuses
+
+**Files:**
+- Modify: `Model/EnrichmentLog.php`
+
+**Step 1: Add the new status constants**
+
+In `Model/EnrichmentLog.php`, add after the existing constants:
+
+```php
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/EnrichmentLog.php
+git commit -m "feat: add approved and rejected statuses to EnrichmentLog (#28)"
+```
+
+---
+
+### Task 4: Update EnrichmentLogger for review workflow
+
+**Files:**
+- Modify: `Model/Product/EnrichmentLogger.php`
+- Test: `Test/Unit/Model/Product/EnrichmentLoggerTest.php`
+
+**Step 1: Update the `log` method signature and add new methods**
+
+Replace the entire `Model/Product/EnrichmentLogger.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class EnrichmentLogger
+{
+    public function __construct(
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogFactory $logFactory,
+        private readonly EnrichmentLogResource $resource
+    ) {
+    }
+
+    public function log(
+        int $entityId,
+        string $attributeCode,
+        int $storeId,
+        string $generatedContent = '',
+        string $originalContent = '',
+        string $promptHash = '',
+        string $status = EnrichmentLog::STATUS_GENERATED
+    ): void {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId()) {
+            $existing->setData('status', $status);
+            $existing->setData('generated_content', $generatedContent);
+            $existing->setData('original_content', $originalContent);
+            $existing->setData('prompt_hash', $promptHash);
+            $this->resource->save($existing);
+        } else {
+            $log = $this->logFactory->create();
+            $log->setData([
+                'entity_id' => $entityId,
+                'attribute_code' => $attributeCode,
+                'store_id' => $storeId,
+                'status' => $status,
+                'generated_content' => $generatedContent,
+                'original_content' => $originalContent,
+                'prompt_hash' => $promptHash,
+            ]);
+            $this->resource->save($log);
+        }
+    }
+
+    public function markModified(int $entityId, string $attributeCode, int $storeId): void
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        if ($existing->getId() && $existing->getData('status') !== EnrichmentLog::STATUS_MODIFIED) {
+            $existing->setData('status', EnrichmentLog::STATUS_MODIFIED);
+            $this->resource->save($existing);
+        }
+    }
+
+    public function approve(int $logId): ?EnrichmentLog
+    {
+        $log = $this->logFactory->create();
+        $this->resource->load($log, $logId);
+
+        if ($log->getId()) {
+            $log->setData('status', EnrichmentLog::STATUS_APPROVED);
+            $this->resource->save($log);
+            return $log;
+        }
+
+        return null;
+    }
+
+    public function reject(int $logId): ?EnrichmentLog
+    {
+        $log = $this->logFactory->create();
+        $this->resource->load($log, $logId);
+
+        if ($log->getId()) {
+            $log->setData('status', EnrichmentLog::STATUS_REJECTED);
+            $this->resource->save($log);
+            return $log;
+        }
+
+        return null;
+    }
+
+    public function findByPromptHash(string $promptHash, string $attributeCode, int $storeId): ?string
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('prompt_hash', $promptHash);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+        $collection->addFieldToFilter('generated_content', ['notnull' => true]);
+        $collection->setPageSize(1);
+
+        $item = $collection->getFirstItem();
+
+        return $item->getId() ? $item->getData('generated_content') : null;
+    }
+
+    public function getStatus(int $entityId, string $attributeCode, int $storeId): ?string
+    {
+        $existing = $this->find($entityId, $attributeCode, $storeId);
+
+        return $existing->getId() ? $existing->getData('status') : null;
+    }
+
+    public function getStatusesForProduct(int $entityId, int $storeId): array
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        $statuses = [];
+        foreach ($collection as $item) {
+            $statuses[$item->getData('attribute_code')] = $item->getData('status');
+        }
+
+        return $statuses;
+    }
+
+    private function find(int $entityId, string $attributeCode, int $storeId): EnrichmentLog
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('entity_id', $entityId);
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('store_id', $storeId);
+
+        return $collection->getFirstItem();
+    }
+}
+```
+
+**Step 2: Update the test**
+
+Replace `Test/Unit/Model/Product/EnrichmentLoggerTest.php` to match the new `log()` signature:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\EnrichmentLogFactory;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog as EnrichmentLogResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class EnrichmentLoggerTest extends TestCase
+{
+    public function test_log_creates_new_entry_with_content_and_hash(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($this->createConfiguredMock(
+            EnrichmentLog::class,
+            ['getId' => null]
+        ));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $newLog = $this->createMock(EnrichmentLog::class);
+        $newLog->expects($this->once())->method('setData')->with($this->callback(
+            fn(array $data) => $data['entity_id'] === 42
+                && $data['attribute_code'] === 'description'
+                && $data['store_id'] === 1
+                && $data['status'] === EnrichmentLog::STATUS_GENERATED
+                && $data['generated_content'] === 'AI output'
+                && $data['original_content'] === 'old value'
+                && $data['prompt_hash'] === 'abc123'
+        ));
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $logFactory->method('create')->willReturn($newLog);
+
+        $resource = $this->createMock(EnrichmentLogResource::class);
+        $resource->expects($this->once())->method('save')->with($newLog);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $logger->log(42, 'description', 1, 'AI output', 'old value', 'abc123');
+    }
+
+    public function test_find_by_prompt_hash_returns_cached_content(): void
+    {
+        $item = $this->createMock(EnrichmentLog::class);
+        $item->method('getId')->willReturn(1);
+        $item->method('getData')->with('generated_content')->willReturn('cached response');
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setPageSize')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($item);
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $logFactory = $this->createMock(EnrichmentLogFactory::class);
+        $resource = $this->createMock(EnrichmentLogResource::class);
+
+        $logger = new EnrichmentLogger($collectionFactory, $logFactory, $resource);
+        $result = $logger->findByPromptHash('hash123', 'description', 1);
+
+        $this->assertEquals('cached response', $result);
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add Model/Product/EnrichmentLogger.php Test/Unit/Model/Product/EnrichmentLoggerTest.php
+git commit -m "feat: extend EnrichmentLogger with approve, reject, prompt hash dedup (#28)"
+```
+
+---
+
+### Task 5: Update Enricher for review mode and deduplication
+
+**Files:**
+- Modify: `Model/Product/Enricher.php`
+
+**Step 1: Update the enrichAttribute method**
+
+In `Model/Product/Enricher.php`, replace the `enrichAttribute` method with:
+
+```php
+    public function enrichAttribute(Product $product, string $attributeCode): void
+    {
+        if (!$product->getData('mageos_catalogai_overwrite') && $product->getData($attributeCode)) {
+            return;
+        }
+        if ($prompt = $this->promptResolver->resolve($attributeCode, $product)) {
+
+            $resolvedPrompt = $this->parsePrompt($prompt, $product);
+            $promptHash = hash('sha256', $resolvedPrompt);
+            $storeId = (int)$product->getStoreId();
+            $originalContent = (string)$product->getData($attributeCode);
+
+            // Check for cached response with same prompt hash
+            $cachedContent = $this->enrichmentLogger->findByPromptHash($promptHash, $attributeCode, $storeId);
+
+            if ($cachedContent !== null) {
+                $generatedContent = $cachedContent;
+            } else {
+                $response = $this->getClient()->chat()->create([
+                    'model' => $this->config->getApiModel(),
+                    'temperature' => $this->config->getTemperature(),
+                    'frequency_penalty' => $this->config->getFrequencyPenalty(),
+                    'presence_penalty' => $this->config->getPresencePenalty(),
+                    'max_completion_tokens' => $this->config->getApiMaxTokens(),
+                    'messages' => [
+                        [
+                            'role' => 'developer',
+                            'content' => $this->config->getSystemPrompt()
+                        ],
+                        [
+                            'role' => 'user',
+                            'content' => $resolvedPrompt
+                        ]
+                    ]
+                ]);
+
+                if (!$result = $response->choices[0]) {
+                    return;
+                }
+                $generatedContent = $result->message?->content ?? '';
+                $this->backoff($response->meta());
+            }
+
+            $status = $this->config->requiresReview()
+                ? EnrichmentLog::STATUS_PENDING_REVIEW
+                : EnrichmentLog::STATUS_GENERATED;
+
+            if (!$this->config->requiresReview()) {
+                $product->setData($attributeCode, $generatedContent);
+            }
+
+            $this->enrichmentLogger->log(
+                (int)$product->getId(),
+                $attributeCode,
+                $storeId,
+                $generatedContent,
+                $originalContent,
+                $promptHash,
+                $status
+            );
+        }
+    }
+```
+
+Also add this import at the top:
+
+```php
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+```
+
+**Step 2: Commit**
+
+```bash
+git add Model/Product/Enricher.php
+git commit -m "feat: Enricher supports review mode and prompt hash deduplication (#28)"
+```
+
+---
+
+### Task 6: Create review grid — controller, layout, UI component
+
+**Files:**
+- Create: `Controller/Adminhtml/Review/Index.php`
+- Create: `view/adminhtml/layout/catalogai_review_index.xml`
+- Create: `view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml`
+- Create: `Model/ResourceModel/EnrichmentLog/Grid/Collection.php`
+- Modify: `etc/adminhtml/menu.xml`
+- Modify: `etc/adminhtml/di.xml`
+- Modify: `etc/acl.xml`
+
+**Step 1: Create the Index controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::enrichment_review');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Enrichment Review'));
+        return $resultPage;
+    }
+}
+```
+
+**Step 2: Create the layout**
+
+`view/adminhtml/layout/catalogai_review_index.xml`:
+
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_enrichment_review_listing"/>
+        </referenceContainer>
+    </body>
+</page>
+```
+
+**Step 3: Create the grid UI component**
+
+`view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_enrichment_review_listing.mageos_catalogai_enrichment_review_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <spinner>mageos_catalogai_enrichment_review_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_enrichment_review_listing.mageos_catalogai_enrichment_review_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_enrichment_review_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_enrichment_review_listing_data_source">
+            <settings>
+                <requestFieldName>log_id</requestFieldName>
+                <primaryFieldName>log_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+        <massaction name="listing_massaction">
+            <action name="approve">
+                <settings>
+                    <url path="catalogai/review/massApprove"/>
+                    <type>approve</type>
+                    <label translate="true">Approve</label>
+                </settings>
+            </action>
+            <action name="reject">
+                <settings>
+                    <confirm>
+                        <message translate="true">Reject and revert selected items?</message>
+                        <title translate="true">Reject</title>
+                    </confirm>
+                    <url path="catalogai/review/massReject"/>
+                    <type>reject</type>
+                    <label translate="true">Reject</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="mageos_catalogai_enrichment_review_columns">
+        <selectionsColumn name="ids">
+            <settings>
+                <indexField>log_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="log_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>desc</sorting>
+            </settings>
+        </column>
+        <column name="entity_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Product ID</label>
+            </settings>
+        </column>
+        <column name="attribute_code">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Attribute</label>
+            </settings>
+        </column>
+        <column name="store_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Store</label>
+            </settings>
+        </column>
+        <column name="status">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Status</label>
+                <dataType>select</dataType>
+                <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichmentStatus"/>
+            </settings>
+        </column>
+        <column name="generated_content">
+            <settings>
+                <label translate="true">Generated Content</label>
+                <bodyTmpl>ui/grid/cells/html</bodyTmpl>
+                <sortable>false</sortable>
+            </settings>
+        </column>
+        <column name="generated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Generated At</label>
+            </settings>
+        </column>
+    </columns>
+</listing>
+```
+
+**Step 4: Create the grid collection**
+
+`Model/ResourceModel/EnrichmentLog/Grid/Collection.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_enrichment_log',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('log_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}
+```
+
+**Step 5: Create the EnrichmentStatus source model**
+
+`Model/Config/Source/EnrichmentStatus.php`:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+
+class EnrichmentStatus implements OptionSourceInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => EnrichmentLog::STATUS_GENERATED, 'label' => __('Generated')],
+            ['value' => EnrichmentLog::STATUS_PENDING_REVIEW, 'label' => __('Pending Review')],
+            ['value' => EnrichmentLog::STATUS_MODIFIED, 'label' => __('Modified')],
+            ['value' => EnrichmentLog::STATUS_APPROVED, 'label' => __('Approved')],
+            ['value' => EnrichmentLog::STATUS_REJECTED, 'label' => __('Rejected')],
+        ];
+    }
+}
+```
+
+**Step 6: Add menu item**
+
+In `etc/adminhtml/menu.xml`, add a second `<add>` entry inside `<menu>`:
+
+```xml
+        <add id="MageOS_CatalogDataAI::enrichment_review"
+             title="AI Enrichment Review"
+             module="MageOS_CatalogDataAI"
+             sortOrder="91"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/review"
+             resource="MageOS_CatalogDataAI::enrichment_review"/>
+```
+
+**Step 7: Add ACL resource**
+
+In `etc/acl.xml`, add after the `prompt_rules` resource:
+
+```xml
+                <resource id="MageOS_CatalogDataAI::enrichment_review" title="AI Enrichment Review" translate="title" sortOrder="51" />
+```
+
+**Step 8: Register the grid data source in adminhtml di.xml**
+
+In `etc/adminhtml/di.xml`, inside the existing `CollectionFactory` `<type>` → `<argument name="collections">` → `<array>`, add:
+
+```xml
+                <item name="mageos_catalogai_enrichment_review_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Grid\Collection</item>
+```
+
+**Step 9: Commit**
+
+```bash
+git add Controller/Adminhtml/Review/Index.php \
+    view/adminhtml/layout/catalogai_review_index.xml \
+    view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml \
+    Model/ResourceModel/EnrichmentLog/Grid/Collection.php \
+    Model/Config/Source/EnrichmentStatus.php \
+    etc/adminhtml/menu.xml \
+    etc/adminhtml/di.xml \
+    etc/acl.xml
+git commit -m "feat: add enrichment review admin grid (#28)"
+```
+
+---
+
+### Task 7: Create MassApprove controller
+
+**Files:**
+- Create: `Controller/Adminhtml/Review/MassApprove.php`
+
+**Step 1: Create the controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class MassApprove extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly ProductRepositoryInterface $productRepository
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $approved = 0;
+
+        foreach ($collection as $logEntry) {
+            $log = $this->enrichmentLogger->approve((int)$logEntry->getId());
+            if ($log) {
+                $product = $this->productRepository->getById(
+                    (int)$log->getData('entity_id'),
+                    true,
+                    (int)$log->getData('store_id')
+                );
+                $product->setData($log->getData('attribute_code'), $log->getData('generated_content'));
+                $this->productRepository->save($product);
+                $approved++;
+            }
+        }
+
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 entry(ies) have been approved and published.', $approved)
+        );
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/Review/MassApprove.php
+git commit -m "feat: add mass approve controller for enrichment review (#28)"
+```
+
+---
+
+### Task 8: Create MassReject controller
+
+**Files:**
+- Create: `Controller/Adminhtml/Review/MassReject.php`
+
+**Step 1: Create the controller**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Review;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\Product\EnrichmentLogger;
+use MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\CollectionFactory;
+
+class MassReject extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::enrichment_review';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly ProductRepositoryInterface $productRepository
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $rejected = 0;
+
+        foreach ($collection as $logEntry) {
+            $log = $this->enrichmentLogger->reject((int)$logEntry->getId());
+            if ($log && $log->getData('original_content') !== null) {
+                $product = $this->productRepository->getById(
+                    (int)$log->getData('entity_id'),
+                    true,
+                    (int)$log->getData('store_id')
+                );
+                $product->setData($log->getData('attribute_code'), $log->getData('original_content'));
+                $this->productRepository->save($product);
+            }
+            $rejected++;
+        }
+
+        $this->messageManager->addSuccessMessage(
+            __('A total of %1 entry(ies) have been rejected.', $rejected)
+        );
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add Controller/Adminhtml/Review/MassReject.php
+git commit -m "feat: add mass reject controller for enrichment review (#28)"
+```
+
+---
+
+### Task 9: Smoke test
+
+**Step 1: Run Magento setup commands (inside Warden)**
+
+```bash
+warden env exec php-fpm bin/magento setup:upgrade
+warden env exec php-fpm bin/magento setup:di:compile
+```
+
+**Step 2: Verify new columns exist**
+
+Check that `generated_content`, `original_content`, and `prompt_hash` columns were added to the enrichment log table.
+
+**Step 3: Verify admin pages**
+
+1. Navigate to **Catalog > AI Enrichment Review** — grid should load
+2. Navigate to **AI Services > Data Enrichment > Settings** — verify "Require Review Before Publish" toggle exists
+3. Enable review mode, trigger an enrichment — verify content goes to pending_review status
+4. In the review grid, approve an entry — verify product attribute is updated
+5. Reject an entry — verify product attribute reverts to original
+
+**Step 4: Run all tests**
+
+```bash
+vendor/bin/phpunit Test/
+```
+
+**Step 5: Final commit (if adjustments needed)**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from smoke testing Phase 4"
+```
+
+---
+
+## Summary of Files Changed/Created
+
+| Action | File |
+|--------|------|
+| **Schema & Config** | |
+| Modify | `etc/db_schema.xml` |
+| Modify | `etc/db_schema_whitelist.json` |
+| Modify | `etc/adminhtml/system.xml` |
+| Modify | `etc/config.xml` |
+| Modify | `Model/Config.php` |
+| Modify | `etc/acl.xml` |
+| Modify | `etc/adminhtml/menu.xml` |
+| Modify | `etc/adminhtml/di.xml` |
+| **Core Logic** | |
+| Modify | `Model/EnrichmentLog.php` |
+| Modify | `Model/Product/EnrichmentLogger.php` |
+| Modify | `Model/Product/Enricher.php` |
+| Modify | `Test/Unit/Model/Product/EnrichmentLoggerTest.php` |
+| **Review Grid** | |
+| Create | `Controller/Adminhtml/Review/Index.php` |
+| Create | `Controller/Adminhtml/Review/MassApprove.php` |
+| Create | `Controller/Adminhtml/Review/MassReject.php` |
+| Create | `Model/ResourceModel/EnrichmentLog/Grid/Collection.php` |
+| Create | `Model/Config/Source/EnrichmentStatus.php` |
+| Create | `view/adminhtml/layout/catalogai_review_index.xml` |
+| Create | `view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml` |

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,10 +6,11 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Magento_Catalog::config_catalog_ai" title="AI Data Enrichment Section" translate="title" />
+                            <resource id="MageOS_CatalogDataAI::config" title="AI Data Enrichment" translate="title" />
                         </resource>
                     </resource>
                 </resource>
+                <resource id="MageOS_CatalogDataAI::prompt_rules" title="AI Prompt Rules" translate="title" sortOrder="50" />
             </resource>
         </resources>
     </acl>

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -11,6 +11,7 @@
                     </resource>
                 </resource>
                 <resource id="MageOS_CatalogDataAI::prompt_rules" title="AI Prompt Rules" translate="title" sortOrder="50" />
+                <resource id="MageOS_CatalogDataAI::enrichment_review" title="AI Enrichment Review" translate="title" sortOrder="51" />
             </resource>
         </resources>
     </acl>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -18,4 +18,14 @@
             </argument>
         </arguments>
     </type>
+    <virtualType name="MageOS\CatalogDataAI\PromptRule\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="conditions" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier\Conditions</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="mageos_catalogai_enrichment_status" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus</item>
+                    <item name="sortOrder" xsi:type="number">200</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
+</config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -15,6 +15,7 @@
         <arguments>
             <argument name="collections" xsi:type="array">
                 <item name="mageos_catalogai_prompt_rule_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid\Collection</item>
+                <item name="mageos_catalogai_enrichment_review_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\EnrichmentLog\Grid\Collection</item>
             </argument>
         </arguments>
     </type>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -11,4 +11,11 @@
             </argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="mageos_catalogai_prompt_rule_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add id="MageOS_CatalogDataAI::prompt_rules"
+             title="AI Prompt Rules"
+             module="MageOS_CatalogDataAI"
+             sortOrder="90"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/promptrule"
+             resource="MageOS_CatalogDataAI::prompt_rules"/>
+    </menu>
+</config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -9,5 +9,12 @@
              parent="Magento_Catalog::catalog"
              action="catalogai/promptrule"
              resource="MageOS_CatalogDataAI::prompt_rules"/>
+        <add id="MageOS_CatalogDataAI::enrichment_review"
+             title="AI Enrichment Review"
+             module="MageOS_CatalogDataAI"
+             sortOrder="91"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/review"
+             resource="MageOS_CatalogDataAI::enrichment_review"/>
     </menu>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,27 +35,17 @@
                     <label>OpenAI API Max Tokens</label>
                 </field>
             </group>
-            <group id="product" translate="label" sortOrder="20" showInDefault="1" showInStore="1">
+            <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
                 <label>Product Fields Auto-Generation</label>
                 <comment>
-                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name}) as product attribute data placeholder
+                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name) as product attribute data placeholder.
                     <br />
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>
-                <field id="short_description" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" canRestore="1">
-                    <label>Short Description</label>
-                </field>
-                <field id="description" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" canRestore="1">
-                    <label>Description</label>
-                </field>
-                <field id="meta_title" translate="label comment" type="textarea" sortOrder="40" showInDefault="1" canRestore="1">
-                    <label>Meta Title</label>
-                </field>
-                <field id="meta_keyword" translate="label comment" type="textarea" sortOrder="50" showInDefault="1" canRestore="1">
-                    <label>Meta Keywords</label>
-                </field>
-                <field id="meta_description" translate="label comment" type="textarea" sortOrder="60" showInDefault="1" canRestore="1">
-                    <label>Meta Description</label>
+                <field id="attribute_prompts" translate="label" sortOrder="10" showInDefault="1" showInStore="1">
+                    <label>Attribute Prompts</label>
+                    <frontend_model>MageOS\CatalogDataAI\Block\Adminhtml\Form\Field\ProductAttributes</frontend_model>
+                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                 </field>
             </group>
             <group id="advanced" translate="label" sortOrder="30" showInDefault="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,15 +62,19 @@
                 <label>Advanced Settings</label>
                 <field id="system_prompt" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
                     <label>System Prompt</label>
+                    <comment><![CDATA[Instructions sent to the AI model as the developer/system role. Defines the AI's behavior.]]></comment>
                 </field>
                 <field id="temperature" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
-                    <label>System Prompt</label>
+                    <label>Temperature</label>
+                    <comment><![CDATA[Controls randomness. 0.0 = deterministic, 1.0 = creative. Default: 0]]></comment>
                 </field>
                 <field id="frequency_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>Frequency Penalty</label>
+                    <comment><![CDATA[Reduces repetition of token sequences. Range: -2.0 to 2.0. Default: 0]]></comment>
                 </field>
-                <field id="presence_penalty" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
+                <field id="presence_penalty" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>Presence Penalty</label>
+                    <comment><![CDATA[Encourages new topics. Range: -2.0 to 2.0. Default: 0]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="catalog_ai" translate="label" type="text" sortOrder="45" showInDefault="1">
+        <tab id="ai_services" translate="label" sortOrder="500">
+            <label>AI Services</label>
+        </tab>
+        <section id="ai_integration_enrichment" translate="label" type="text" sortOrder="10" showInDefault="1">
             <class>separator-top</class>
-            <label>AI Data Enrichment</label>
-            <tab>catalog</tab>
-            <resource>Magento_Catalog::config_catalog_ai</resource>
+            <label>Data Enrichment</label>
+            <tab>ai_services</tab>
+            <resource>MageOS_CatalogDataAI::config</resource>
             <group id="settings" translate="label" sortOrder="10" showInDefault="1">
                 <label>Settings</label>
                 <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
@@ -16,7 +19,7 @@
                     <label>Asynchronous enrichment</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="openai_organization_id" translate="label comment" sortOrder="20" showInDefault="1" canRestore="1">
+                <field id="openai_organization_id" translate="label comment" sortOrder="25" showInDefault="1" canRestore="1">
                     <label>OpenAI Organization ID</label>
                 </field>
                 <field id="openai_key" translate="label comment" type="obscure" sortOrder="30" showInDefault="1" canRestore="1">
@@ -24,21 +27,21 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
                 <field id="openai_project_id" translate="label" sortOrder="35" showInDefault="1" canRestore="1">
-                    <label>Open AI Project ID</label>
+                    <label>OpenAI Project ID</label>
                 </field>
                 <field id="openai_model" translate="label comment" type="select" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>OpenAI API Model</label>
                     <source_model>MageOS\CatalogDataAI\Model\Config\Source\OpenAIModel</source_model>
-                    <comment>Insert api key and organization ID and save to see options. Refer to the documentation to understand which model you should select: https://platform.openai.com/docs/models/overview</comment>
+                    <comment>Insert API key and organization ID and save to see options. Refer to the documentation to understand which model you should select: https://platform.openai.com/docs/models/overview</comment>
                 </field>
-                <field id="openai_max_tokens" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
+                <field id="openai_max_tokens" translate="label comment" type="text" sortOrder="45" showInDefault="1" canRestore="1">
                     <label>OpenAI API Max Tokens</label>
                 </field>
             </group>
             <group id="product" translate="label comment" sortOrder="20" showInDefault="1" showInStore="1">
-                <label>Product Fields Auto-Generation</label>
+                <label>Default Product Prompts</label>
                 <comment>
-                    <![CDATA[Use {{product_attribute_code}} (e.g. {{name}} for product name) as product attribute data placeholder.
+                    <![CDATA[Default prompts used when no matching prompt rule exists. Use {{product_attribute_code}} (e.g. {{name}} for product name) as a placeholder.
                     <br />
                     To enrich a meta attribute, the corresponding default value (mask) must be removed, see <a href="https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/product-workspace.html#edit-the-placeholder-value">Edit the placeholder value</a>]]>
                 </comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,6 +19,11 @@
                     <label>Asynchronous enrichment</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="require_review" translate="label comment" type="select" sortOrder="22" showInDefault="1" canRestore="1">
+                    <label>Require Review Before Publish</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[When enabled, AI-generated content is held for review and not written to products until approved.]]></comment>
+                </field>
                 <field id="openai_organization_id" translate="label comment" sortOrder="25" showInDefault="1" canRestore="1">
                     <label>OpenAI Organization ID</label>
                 </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
-        <catalog_ai>
+        <ai_integration_enrichment>
             <settings>
                 <openai_organization_id />
                 <openai_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
@@ -44,6 +44,6 @@
                 <frequency_penalty>0</frequency_penalty>
                 <presence_penalty>0</presence_penalty>
             </advanced>
-        </catalog_ai>
+        </ai_integration_enrichment>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,7 @@
                 <openai_project_id />
                 <openai_model>gpt-4o</openai_model>
                 <openai_max_tokens>1000</openai_max_tokens>
+                <require_review>0</require_review>
             </settings>
             <product>
                 <attribute_prompts>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,8 +10,33 @@
                 <openai_max_tokens>1000</openai_max_tokens>
             </settings>
             <product>
-                <short_description>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</short_description>
-                <description>write a detailed product description for {{name}} with features in bullet list, under 1000 words</description>
+                <attribute_prompts>
+                    <short_description>
+                        <attribute>short_description</attribute>
+                        <prompt>write a very short product description for {{name}} to highlight reasoning for purchase, under 100 words</prompt>
+                        <enabled>1</enabled>
+                    </short_description>
+                    <description>
+                        <attribute>description</attribute>
+                        <prompt>write a detailed product description for {{name}} with features in bullet list, under 1000 words</prompt>
+                        <enabled>1</enabled>
+                    </description>
+                    <meta_title>
+                        <attribute>meta_title</attribute>
+                        <prompt>write a concise SEO meta title for {{name}}, under 60 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_title>
+                    <meta_keyword>
+                        <attribute>meta_keyword</attribute>
+                        <prompt>generate comma-separated SEO keywords for {{name}}, max 10 keywords</prompt>
+                        <enabled>1</enabled>
+                    </meta_keyword>
+                    <meta_description>
+                        <attribute>meta_description</attribute>
+                        <prompt>write an SEO meta description for {{name}}, under 160 characters</prompt>
+                        <enabled>1</enabled>
+                    </meta_description>
+                </attribute_prompts>
             </product>
             <advanced>
                 <system_prompt>Be a content generator, just reply with the content, skip all introductions.</system_prompt>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="mageos_catalogai_enrichment_log" resource="default" engine="innodb"
+           comment="AI Enrichment Status Log">
+        <column xsi:type="int" name="log_id" unsigned="true" nullable="false" identity="true"
+                comment="Log ID"/>
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false"
+                comment="Product Entity ID"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Attribute Code"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" default="0"
+                comment="Store ID"/>
+        <column xsi:type="varchar" name="status" nullable="false" length="32" default="generated"
+                comment="Enrichment Status"/>
+        <column xsi:type="timestamp" name="generated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Generation Timestamp"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Last Updated"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="log_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE">
+            <column name="entity_id"/>
+            <column name="attribute_code"/>
+            <column name="store_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_STATUS" indexType="btree">
+            <column name="status"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID" indexType="btree">
+            <column name="entity_id"/>
+        </index>
+    </table>
+</schema>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -13,6 +13,12 @@
                 comment="Store ID"/>
         <column xsi:type="varchar" name="status" nullable="false" length="32" default="generated"
                 comment="Enrichment Status"/>
+        <column xsi:type="text" name="generated_content" nullable="true"
+                comment="AI Generated Content"/>
+        <column xsi:type="text" name="original_content" nullable="true"
+                comment="Original Content Before Enrichment"/>
+        <column xsi:type="varchar" name="prompt_hash" nullable="true" length="64"
+                comment="SHA-256 Hash of Resolved Prompt"/>
         <column xsi:type="timestamp" name="generated_at" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Generation Timestamp"/>
         <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
@@ -30,6 +36,9 @@
         </index>
         <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID" indexType="btree">
             <column name="entity_id"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_ENRICH_LOG_PROMPT_HASH" indexType="btree">
+            <column name="prompt_hash"/>
         </index>
     </table>
     <table name="mageos_catalogai_prompt_rule" resource="default" engine="innodb"

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -32,4 +32,36 @@
             <column name="entity_id"/>
         </index>
     </table>
+    <table name="mageos_catalogai_prompt_rule" resource="default" engine="innodb"
+           comment="AI Prompt Rules">
+        <column xsi:type="int" name="rule_id" unsigned="true" nullable="false" identity="true"
+                comment="Rule ID"/>
+        <column xsi:type="varchar" name="name" nullable="false" length="255"
+                comment="Rule Name"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Target Attribute Code"/>
+        <column xsi:type="text" name="store_ids" nullable="false"
+                comment="Store IDs (comma-separated, 0 = all)"/>
+        <column xsi:type="text" name="conditions_serialized" nullable="true"
+                comment="Serialized Product Conditions"/>
+        <column xsi:type="text" name="prompt" nullable="false"
+                comment="Prompt Template"/>
+        <column xsi:type="int" name="priority" unsigned="false" nullable="false" default="0"
+                comment="Priority (highest wins)"/>
+        <column xsi:type="boolean" name="is_active" nullable="false" default="true"
+                comment="Is Active"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="rule_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE" indexType="btree">
+            <column name="attribute_code"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE" indexType="btree">
+            <column name="is_active"/>
+        </index>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -6,6 +6,9 @@
             "attribute_code": true,
             "store_id": true,
             "status": true,
+            "generated_content": true,
+            "original_content": true,
+            "prompt_hash": true,
             "generated_at": true,
             "updated_at": true
         },
@@ -15,7 +18,8 @@
         },
         "index": {
             "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
-            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_PROMPT_HASH": true
         }
     },
     "mageos_catalogai_prompt_rule": {

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,0 +1,21 @@
+{
+    "mageos_catalogai_enrichment_log": {
+        "column": {
+            "log_id": true,
+            "entity_id": true,
+            "attribute_code": true,
+            "store_id": true,
+            "status": true,
+            "generated_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ATTR_STORE": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
+            "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
+        }
+    }
+}

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -17,5 +17,26 @@
             "MAGEOS_CATALOGAI_ENRICH_LOG_STATUS": true,
             "MAGEOS_CATALOGAI_ENRICH_LOG_ENTITY_ID": true
         }
+    },
+    "mageos_catalogai_prompt_rule": {
+        "column": {
+            "rule_id": true,
+            "name": true,
+            "attribute_code": true,
+            "store_ids": true,
+            "conditions_serialized": true,
+            "prompt": true,
+            "priority": true,
+            "is_active": true,
+            "created_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE": true,
+            "MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE": true
+        }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,9 +3,9 @@
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="sensitive" xsi:type="array">
-                <item name="catalog_ai/settings/openai_organization_id" xsi:type="string">1</item>
-                <item name="catalog_ai/settings/openai_key" xsi:type="string">1</item>
-                <item name="catalog_ai/settings/openai_project_id" xsi:type="string">1</item>
+                <item name="ai_integration_enrichment/settings/openai_organization_id" xsi:type="string">1</item>
+                <item name="ai_integration_enrichment/settings/openai_key" xsi:type="string">1</item>
+                <item name="ai_integration_enrichment/settings/openai_project_id" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="MageOS_CatalogDataAI">
         <sequence>
             <module name="Magento_Catalog"/>
+            <module name="Magento_Store"/>
         </sequence>
     </module>
 </config>

--- a/registration.php
+++ b/registration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 \Magento\Framework\Component\ComponentRegistrar::register(

--- a/view/adminhtml/layout/catalogai_promptrule_edit.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_edit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_promptrule_index.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_promptrule_new.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_new.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_review_index.xml
+++ b/view/adminhtml/layout/catalogai_review_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_enrichment_review_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_enrichment_review_listing.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_enrichment_review_listing.mageos_catalogai_enrichment_review_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <spinner>mageos_catalogai_enrichment_review_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_enrichment_review_listing.mageos_catalogai_enrichment_review_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_enrichment_review_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_enrichment_review_listing_data_source">
+            <settings>
+                <requestFieldName>log_id</requestFieldName>
+                <primaryFieldName>log_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+        <massaction name="listing_massaction">
+            <action name="approve">
+                <settings>
+                    <url path="catalogai/review/massApprove"/>
+                    <type>approve</type>
+                    <label translate="true">Approve</label>
+                </settings>
+            </action>
+            <action name="reject">
+                <settings>
+                    <confirm>
+                        <message translate="true">Reject and revert selected items?</message>
+                        <title translate="true">Reject</title>
+                    </confirm>
+                    <url path="catalogai/review/massReject"/>
+                    <type>reject</type>
+                    <label translate="true">Reject</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="mageos_catalogai_enrichment_review_columns">
+        <selectionsColumn name="ids">
+            <settings>
+                <indexField>log_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="log_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>desc</sorting>
+            </settings>
+        </column>
+        <column name="entity_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Product ID</label>
+            </settings>
+        </column>
+        <column name="attribute_code">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Attribute</label>
+            </settings>
+        </column>
+        <column name="store_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Store</label>
+            </settings>
+        </column>
+        <column name="status">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Status</label>
+                <dataType>select</dataType>
+                <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichmentStatus"/>
+            </settings>
+        </column>
+        <column name="generated_content">
+            <settings>
+                <label translate="true">Generated Content</label>
+                <bodyTmpl>ui/grid/cells/html</bodyTmpl>
+                <sortable>false</sortable>
+            </settings>
+        </column>
+        <column name="generated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Generated At</label>
+            </settings>
+        </column>
+    </columns>
+</listing>

--- a/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Prompt Rule</item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="back">
+                <url path="*/*/"/>
+                <class>back</class>
+                <label translate="true">Back</label>
+            </button>
+            <button name="delete" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\DeleteButton"/>
+            <button name="save" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\SaveButton"/>
+        </buttons>
+        <namespace>mageos_catalogai_prompt_rule_form</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_form_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="catalogai/promptrule/save"/>
+        </settings>
+        <dataProvider class="MageOS\CatalogDataAI\Model\PromptRule\DataProvider" name="mageos_catalogai_prompt_rule_form_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general">
+        <settings>
+            <label translate="true">Rule Information</label>
+        </settings>
+        <field name="rule_id" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+            </settings>
+        </field>
+        <field name="name" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Rule Name</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="is_active" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="default" xsi:type="number">1</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Active</label>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="number">0</map>
+                            <map name="true" xsi:type="number">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+        <field name="attribute_code" formElement="select">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Target Attribute</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+            <formElements>
+                <select>
+                    <settings>
+                        <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichableAttributes"/>
+                    </settings>
+                </select>
+            </formElements>
+        </field>
+        <field name="store_ids" formElement="multiselect">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Store Views</label>
+                <tooltip>
+                    <description translate="true">Select store views this rule applies to. Leave empty or select "All Store Views" for all stores.</description>
+                </tooltip>
+            </settings>
+            <formElements>
+                <multiselect>
+                    <settings>
+                        <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
+                    </settings>
+                </multiselect>
+            </formElements>
+        </field>
+        <field name="priority" formElement="input">
+            <settings>
+                <dataType>number</dataType>
+                <label translate="true">Priority</label>
+                <notice translate="true">Higher value = higher priority. When multiple rules match, the one with the highest priority wins.</notice>
+                <validation>
+                    <rule name="validate-digits" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+    <fieldset name="prompt_fieldset">
+        <settings>
+            <label translate="true">Prompt</label>
+        </settings>
+        <field name="prompt" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Prompt Template</label>
+                <notice translate="true">Use {{attribute_code}} placeholders for product data (e.g. {{name}}, {{price}}).</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+</form>

--- a/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="add">
+                <url path="catalogai/promptrule/new"/>
+                <class>primary</class>
+                <label translate="true">Add New Rule</label>
+            </button>
+        </buttons>
+        <spinner>mageos_catalogai_prompt_rule_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_prompt_rule_listing_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+        <massaction name="listing_massaction">
+            <action name="delete">
+                <settings>
+                    <confirm>
+                        <message translate="true">Delete selected rules?</message>
+                        <title translate="true">Delete</title>
+                    </confirm>
+                    <url path="catalogai/promptrule/massDelete"/>
+                    <type>delete</type>
+                    <label translate="true">Delete</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="mageos_catalogai_prompt_rule_columns">
+        <selectionsColumn name="ids">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="rule_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>asc</sorting>
+            </settings>
+        </column>
+        <column name="name">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Name</label>
+            </settings>
+        </column>
+        <column name="attribute_code">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Attribute</label>
+            </settings>
+        </column>
+        <column name="priority">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Priority</label>
+            </settings>
+        </column>
+        <column name="is_active" component="Magento_Ui/js/grid/columns/select">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Active</label>
+                <dataType>select</dataType>
+                <options class="Magento\Config\Model\Config\Source\Yesno"/>
+            </settings>
+        </column>
+        <column name="updated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Updated</label>
+            </settings>
+        </column>
+        <actionsColumn name="actions" class="MageOS\CatalogDataAI\Ui\Component\Listing\Column\PromptRuleActions">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </actionsColumn>
+    </columns>
+</listing>


### PR DESCRIPTION
## Summary

- **Fixes #28**: Admin review grid for AI-generated content with approve/reject/revert workflow, "require review" config toggle, and prompt hash-based content deduplication

**Depends on:** #54 (Phase 3: Prompt Rules Engine + Config Migration)

## Review/Approval Workflow Details

**Schema changes:**
- Added `generated_content` (text), `original_content` (text), and `prompt_hash` (varchar 64, indexed) columns to `mageos_catalogai_enrichment_log`

**Review mode config:**
- New "Require Review Before Publish" toggle under AI Services > Data Enrichment > Settings
- When enabled, AI-generated content is stored in the log with `pending_review` status but NOT written to the product
- Admin must explicitly approve content before it goes live

**Enrichment statuses expanded:**
- `generated` — AI content written directly to product (review not required)
- `pending_review` — AI content held for review (review required)
- `modified` — admin manually edited an AI-generated field
- `approved` — admin approved pending content, now written to product
- `rejected` — admin rejected content, product reverted to original

**Content deduplication:**
- Before calling OpenAI, the Enricher computes a SHA-256 hash of the resolved prompt (after variable substitution)
- Checks for an existing log entry with the same hash + attribute + store
- If found, reuses the cached content instead of making a redundant API call
- Cache invalidates automatically when prompt text or product data changes (hash won't match)

**Review admin grid:**
- New menu item: Catalog > AI Enrichment Review
- Columns: ID, Product ID, Attribute, Store, Status (filterable dropdown), Generated Content, Generated At
- Mass actions: Approve (writes content to product), Reject (reverts to original content)

## Test plan

- [ ] Run `setup:upgrade` — should add 3 new columns to enrichment_log table
- [ ] Run `setup:di:compile` — should complete without errors
- [ ] Verify "Require Review Before Publish" toggle appears in admin config
- [ ] With review disabled: enrich a product, verify content is written directly (status = `generated`)
- [ ] With review enabled: enrich a product, verify content is NOT on the product (status = `pending_review`)
- [ ] Navigate to Catalog > AI Enrichment Review — grid should show pending entries
- [ ] Mass approve entries — verify content appears on the product
- [ ] Mass reject entries — verify product reverts to original content
- [ ] Enrich the same product twice with identical data — verify second call uses cached content (no API call)
- [ ] Change product name, re-enrich — verify fresh API call is made (hash changed)