### PR TITLE
chore: adopt PSR-12 via PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+.php-cs-fixer.cache
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude(['vendor', 'Test/Unit/bootstrap.php']);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        'declare_strict_types' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+    ])
+    ->setFinder($finder);

--- a/Api/EnrichmentRepositoryInterface.php
+++ b/Api/EnrichmentRepositoryInterface.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
-use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
 
 interface EnrichmentRepositoryInterface
 {

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;

--- a/Block/Adminhtml/Form/Field/AttributeColumn.php
+++ b/Block/Adminhtml/Form/Field/AttributeColumn.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;

--- a/Block/Adminhtml/Form/Field/AttributePrompts.php
+++ b/Block/Adminhtml/Form/Field/AttributePrompts.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;

--- a/Block/Adminhtml/Form/Field/PromptColumn.php
+++ b/Block/Adminhtml/Form/Field/PromptColumn.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\Form\Field;

--- a/Controller/Adminhtml/Enrichment/Save.php
+++ b/Controller/Adminhtml/Enrichment/Save.php
@@ -69,9 +69,9 @@ class Save extends Action
             }
 
             $shouldApply = (
-                    $newStatus === EnrichmentInterface::STATUS_APPROVED
+                $newStatus === EnrichmentInterface::STATUS_APPROVED
                     || $newStatus === EnrichmentInterface::STATUS_APPLIED
-                ) && $enrichment->getStatus() !== EnrichmentInterface::STATUS_APPLIED;
+            ) && $enrichment->getStatus() !== EnrichmentInterface::STATUS_APPLIED;
 
             if ($shouldApply) {
                 $this->enrichmentApplier->apply($enrichment);

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
 
+use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Backend\App\Action;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
@@ -41,7 +42,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
-        if($this->config->isEnabled()) {
+        if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
@@ -54,8 +55,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
                     __('A total of %1 record(s) are scheduled to get data enriched.', $productEnriched)
                 );
             }
-        }
-        else {
+        } else {
             $this->messageManager->addErrorMessage(
                 __('Data enrichment is disabled. Please enable it in the configuration.')
             );

--- a/Controller/Adminhtml/Product/MassEnrichSafe.php
+++ b/Controller/Adminhtml/Product/MassEnrichSafe.php
@@ -1,9 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
-
-use MageOS\CatalogDataAI\Controller\Adminhtml\Product\MassEnrich;
 
 class MassEnrichSafe extends MassEnrich
 {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;
 
+use Magento\Catalog\Model\Product;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Catalog\Model\Product;
 
 class Config
 {
@@ -30,7 +31,8 @@ class Config
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly Json $json
-    ) {}
+    ) {
+    }
 
     public function isEnabled(): bool
     {

--- a/Model/Config/Source/OpenAIModel.php
+++ b/Model/Config/Source/OpenAIModel.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MageOS\CatalogDataAI\Model\Config\Source;
 
+use Exception;
 use Magento\Framework\Data\OptionSourceInterface;
+use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
 use OpenAI;
 use OpenAI\Client as OpenAIClient;
-use MageOS\CatalogDataAI\Model\Config as ModuleConfig;
-use Exception;
 
 class OpenAIModel implements OptionSourceInterface
 {
@@ -65,7 +67,7 @@ class OpenAIModel implements OptionSourceInterface
                 foreach ($models['data'] as $model) {
                     $optionArray[] = [
                         'value' => $model['id'],
-                        'label' => $model['id']
+                        'label' => $model['id'],
                     ];
                 }
             } catch (Exception $e) {

--- a/Model/Enrichment.php
+++ b/Model/Enrichment.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
 use Magento\Framework\Model\AbstractModel;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
 
 class Enrichment extends AbstractModel implements EnrichmentInterface
 {

--- a/Model/EnrichmentRepository.php
+++ b/Model/EnrichmentRepository.php
@@ -8,19 +8,18 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
-use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
-use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterfaceFactory;
-use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
-use MageOS\CatalogDataAI\Model\EnrichmentFactory;
-use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment as EnrichmentResource;
-use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment\CollectionFactory;
-use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\DB\Adapter\DuplicateException;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterfaceFactory;
+use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
+use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment as EnrichmentResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment\CollectionFactory;
 
 class EnrichmentRepository implements EnrichmentRepositoryInterface
 {

--- a/Model/OpenAiClient.php
+++ b/Model/OpenAiClient.php
@@ -41,13 +41,13 @@ class OpenAiClient implements AiClientInterface
             'messages' => [
                 [
                     'role' => 'developer',
-                    'content' => $systemPrompt
+                    'content' => $systemPrompt,
                 ],
                 [
                     'role' => 'user',
-                    'content' => $userPrompt
-                ]
-            ]
+                    'content' => $userPrompt,
+                ],
+            ],
         ]);
 
         $this->backoff($response->meta());
@@ -71,12 +71,12 @@ class OpenAiClient implements AiClientInterface
 
     public function backoff(MetaInformation $meta): void
     {
-        if($meta->requestLimit->remaining < 1) {
+        if ($meta->requestLimit->remaining < 1) {
             sleep($this->strToSeconds($meta->requestLimit->reset));
         }
         // 1 token ~= 0.75 word
         // do not use config value
-        if($meta->tokenLimit->remaining < 1000) {
+        if ($meta->tokenLimit->remaining < 1000) {
             sleep($this->strToSeconds($meta->tokenLimit->reset));
         }
     }

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -19,7 +20,8 @@ class Consumer
         private readonly Enricher          $enricher,
         private readonly ProductRepository $productRepository,
         private readonly StoreManagerInterface $storeManager
-    ) {}
+    ) {
+    }
 
     public function execute(Request $request): void
     {

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -1,14 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
 
 use Magento\Framework\MessageQueue\PublisherInterface;
-use MageOS\CatalogDataAI\Model\Product\RequestFactory;
 
 class Publisher
 {
-    const TOPIC_NAME = 'mageos.product.enrich';
+    public const TOPIC_NAME = 'mageos.product.enrich';
 
     /**
      * Publisher constructor.
@@ -16,7 +16,8 @@ class Publisher
     public function __construct(
         private readonly PublisherInterface $publisher,
         private readonly RequestFactory     $requestFactory,
-    ) {}
+    ) {
+    }
 
     /**
      * @param int|string $productId
@@ -26,7 +27,7 @@ class Publisher
     {
         $request = $this->requestFactory->create([
             'id' => (int)$productId,
-            'overwrite' => $overwrite
+            'overwrite' => $overwrite,
         ]);
         $this->publisher->publish(self::TOPIC_NAME, $request);
     }

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/ResourceModel/Enrichment/Collection.php
+++ b/Model/ResourceModel/Enrichment/Collection.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel\Enrichment;
 
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use MageOS\CatalogDataAI\Model\Enrichment;
 use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment as EnrichmentResource;
-use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 class Collection extends AbstractCollection
 {

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\EnrichmentRecorder;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
@@ -16,7 +17,8 @@ class SaveAfter implements ObserverInterface
         private readonly Config $config,
         private readonly Publisher $publisher,
         private readonly EnrichmentRecorder $enrichmentRecorder
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
@@ -25,7 +27,7 @@ class SaveAfter implements ObserverInterface
 
         $this->persistDeferredEnrichments($product);
 
-        if($this->config->canEnrich($product) && $this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && $this->config->isAsync()) {
             $this->publisher->execute($product->getId(), false);
         }
     }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Observer\Product;
 
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 
@@ -14,14 +15,15 @@ class SaveBefore implements ObserverInterface
     public function __construct(
         private readonly Config $config,
         private readonly Enricher $enricher
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer): void
     {
         /** @var Product $product */
         $product = $observer->getProduct();
 
-        if($this->config->canEnrich($product) && !$this->config->isAsync()) {
+        if ($this->config->canEnrich($product) && !$this->config->isAsync()) {
             $this->enricher->execute($product);
         }
     }

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Test\Unit\Model;
 
-use MageOS\CatalogDataAI\Model\Config;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Model\ScopeInterface;
+use MageOS\CatalogDataAI\Model\Config;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -329,7 +329,7 @@ class ConfigTest extends TestCase
     {
         $jsonString = '[{"attribute_code":"description","prompt":"Generate description"}]';
         $arrayData = [
-            ['attribute_code' => 'description', 'prompt' => 'Generate description']
+            ['attribute_code' => 'description', 'prompt' => 'Generate description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -348,7 +348,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptWithArrayInput(): void
     {
         $arrayData = [
-            ['attribute_code' => 'short_description', 'prompt' => 'Generate short description']
+            ['attribute_code' => 'short_description', 'prompt' => 'Generate short description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -409,7 +409,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptWithMissingAttributeCode(): void
     {
         $arrayData = [
-            ['prompt' => 'Generate description']
+            ['prompt' => 'Generate description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -423,7 +423,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptWithMissingPrompt(): void
     {
         $arrayData = [
-            ['attribute_code' => 'description']
+            ['attribute_code' => 'description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -437,7 +437,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptWithEmptyAttributeCode(): void
     {
         $arrayData = [
-            ['attribute_code' => '', 'prompt' => 'Generate description']
+            ['attribute_code' => '', 'prompt' => 'Generate description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -451,7 +451,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptWithEmptyPrompt(): void
     {
         $arrayData = [
-            ['attribute_code' => 'description', 'prompt' => '']
+            ['attribute_code' => 'description', 'prompt' => ''],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -466,7 +466,7 @@ class ConfigTest extends TestCase
     {
         $storeId = 1;
         $arrayData = [
-            ['attribute_code' => 'description', 'prompt' => 'Store-specific prompt']
+            ['attribute_code' => 'description', 'prompt' => 'Store-specific prompt'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -484,7 +484,7 @@ class ConfigTest extends TestCase
     public function testGetProductPromptReturnsNullForNonExistentAttribute(): void
     {
         $arrayData = [
-            ['attribute_code' => 'description', 'prompt' => 'Generate description']
+            ['attribute_code' => 'description', 'prompt' => 'Generate description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -499,7 +499,7 @@ class ConfigTest extends TestCase
     {
         $arrayData = [
             'invalid-row',
-            ['attribute_code' => 'description', 'prompt' => 'Generate description']
+            ['attribute_code' => 'description', 'prompt' => 'Generate description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -514,7 +514,7 @@ class ConfigTest extends TestCase
     {
         $arrayData = [
             ['attribute_code' => 'description', 'prompt' => 'Generate description'],
-            ['attribute_code' => 'short_description', 'prompt' => 'Generate short description']
+            ['attribute_code' => 'short_description', 'prompt' => 'Generate short description'],
         ];
 
         $this->scopeConfig->expects($this->once())
@@ -539,7 +539,7 @@ class ConfigTest extends TestCase
     {
         $storeId = 2;
         $arrayData = [
-            ['attribute_code' => 'meta_title', 'prompt' => 'Generate meta title']
+            ['attribute_code' => 'meta_title', 'prompt' => 'Generate meta title'],
         ];
 
         $this->scopeConfig->expects($this->once())

--- a/Test/Unit/Model/EnrichmentRepositoryTest.php
+++ b/Test/Unit/Model/EnrichmentRepositoryTest.php
@@ -8,7 +8,12 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Test\Unit\Model;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\DB\Adapter\DuplicateException;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
 use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterfaceFactory;
 use MageOS\CatalogDataAI\Model\Enrichment;
@@ -17,12 +22,6 @@ use MageOS\CatalogDataAI\Model\EnrichmentRepository;
 use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment as EnrichmentResource;
 use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment\Collection;
 use MageOS\CatalogDataAI\Model\ResourceModel\Enrichment\CollectionFactory;
-use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
-use Magento\Framework\DB\Adapter\DuplicateException;
-use Magento\Framework\Exception\CouldNotDeleteException;
-use Magento\Framework\Exception\CouldNotSaveException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -164,7 +164,7 @@ class EnricherTest extends TestCase
 
         $this->enricher->enrichAttribute($product, 'description');
 
-        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn($c) => $c['key'] === 'description');
+        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn ($c) => $c['key'] === 'description');
         $this->assertEmpty($descriptionCalls);
     }
 
@@ -183,7 +183,7 @@ class EnricherTest extends TestCase
 
         $this->enricher->enrichAttribute($product, 'description');
 
-        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn($c) => $c['key'] === 'description');
+        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn ($c) => $c['key'] === 'description');
         $this->assertEmpty($descriptionCalls);
     }
 
@@ -246,7 +246,7 @@ class EnricherTest extends TestCase
 
         $deferredCalls = array_filter(
             $this->getProductSetDataCalls(),
-            fn($c) => $c['key'] === 'mageos_catalogai_deferred_enrichments'
+            fn ($c) => $c['key'] === 'mageos_catalogai_deferred_enrichments'
         );
         $this->assertNotEmpty($deferredCalls);
 
@@ -280,7 +280,7 @@ class EnricherTest extends TestCase
 
         $this->enricher->enrichAttribute($product, 'description');
 
-        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn($c) => $c['key'] === 'description');
+        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn ($c) => $c['key'] === 'description');
         $this->assertEmpty($descriptionCalls);
     }
 
@@ -294,7 +294,7 @@ class EnricherTest extends TestCase
 
         $this->enricher->enrichAttribute($product, 'description');
 
-        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn($c) => $c['key'] === 'description');
+        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn ($c) => $c['key'] === 'description');
         $this->assertEmpty($descriptionCalls);
     }
 
@@ -339,7 +339,7 @@ class EnricherTest extends TestCase
 
         $this->enricher->enrichAttribute($product, 'description');
 
-        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn($c) => $c['key'] === 'description');
+        $descriptionCalls = array_filter($this->getProductSetDataCalls(), fn ($c) => $c['key'] === 'description');
         $this->assertEmpty($descriptionCalls);
     }
 

--- a/Test/Unit/Model/Product/PublisherTest.php
+++ b/Test/Unit/Model/Product/PublisherTest.php
@@ -41,7 +41,7 @@ class PublisherTest extends TestCase
             ->method('create')
             ->with([
                 'id' => $productId,
-                'overwrite' => $overwrite
+                'overwrite' => $overwrite,
             ])
             ->willReturn($request);
 
@@ -79,7 +79,7 @@ class PublisherTest extends TestCase
             ->method('create')
             ->with([
                 'id' => $productId,
-                'overwrite' => false
+                'overwrite' => false,
             ])
             ->willReturn($request);
 
@@ -101,7 +101,7 @@ class PublisherTest extends TestCase
             ->method('create')
             ->with([
                 'id' => 42,
-                'overwrite' => $overwrite
+                'overwrite' => $overwrite,
             ])
             ->willReturn($request);
 

--- a/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatusTest.php
+++ b/Test/Unit/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatusTest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Test\Unit\Ui\DataProvider\Product\Form\Modifier;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
-use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
-use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
-use MageOS\CatalogDataAI\Model\Config;
-use MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus;
+use Magento\Backend\Model\UrlInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Store\Api\Data\StoreInterface;
-use Magento\Backend\Model\UrlInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentSearchResultsInterface;
+use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier\EnrichmentStatus;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -248,7 +248,7 @@ class EnrichmentStatusTest extends TestCase
         $product = $this->locator->getProduct();
         if ($product instanceof MockObject) {
             $product->method('getData')
-                ->willReturnCallback(fn(string $key) => $key === $attributeCode ? $value : null);
+                ->willReturnCallback(fn (string $key) => $key === $attributeCode ? $value : null);
         }
     }
 
@@ -295,14 +295,14 @@ class EnrichmentStatusTest extends TestCase
                                             'formElement' => 'textarea',
                                             'visible' => true,
                                             'label' => ucfirst($attributeCode),
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/Test/Unit/bootstrap.php
+++ b/Test/Unit/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Bootstrap for standalone unit tests (CI).
  *

--- a/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
+++ b/Ui/DataProvider/Product/Form/Modifier/EnrichmentStatus.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Ui\DataProvider\Product\Form\Modifier;
 
-use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
-use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
-use MageOS\CatalogDataAI\Model\Config;
+use Magento\Backend\Model\UrlInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Stdlib\ArrayManager;
-use Magento\Backend\Model\UrlInterface;
+use MageOS\CatalogDataAI\Api\Data\EnrichmentInterface;
+use MageOS\CatalogDataAI\Api\EnrichmentRepositoryInterface;
+use MageOS\CatalogDataAI\Model\Config;
 
 class EnrichmentStatus extends AbstractModifier
 {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "openai-php/client": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5||^10.0"
+        "phpunit/phpunit": "^9.5||^10.0",
+        "friendsofphp/php-cs-fixer": "^3.95"
     },
     "autoload": {
         "files": [

--- a/registration.php
+++ b/registration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 \Magento\Framework\Component\ComponentRegistrar::register(


### PR DESCRIPTION
## Summary

Closes #23. This is the one piece that didn't land with #38 / #45 / #46 / #51 and was carried over from the now-closed #52 bundle.

## What this adds

- **Dev dependency:** `friendsofphp/php-cs-fixer` via composer `require-dev`
- **Config:** `.php-cs-fixer.dist.php` at the project root with:
  - `@PSR12` preset
  - `declare_strict_types` (already the convention in this module)
  - Short array syntax
  - Unused import pruning
  - Alpha-sorted imports
  - Trailing comma in multiline arrays
- **Fixes applied** across 28 existing PHP files. Mostly: blank line after `<?php`, alpha-sorting of `use` statements, trailing commas in arrays.
- **.gitignore** for `/vendor`, `composer.lock`, and the two cache files the tools produce.

## What this does NOT change

- No behavior changes.
- No new runtime dependencies.
- Full unit suite (147 tests, 312 assertions) still green.

## Test plan

- [ ] `composer install` succeeds on a fresh clone
- [ ] `vendor/bin/php-cs-fixer fix --dry-run` reports zero violations on current HEAD
- [ ] `vendor/bin/phpunit` runs green