### PR TITLE
feat: store-scoped enrichment with locale-aware system prompts (#12)

### DIFF
--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;

--- a/Api/RequestInterface.php
+++ b/Api/RequestInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api;
@@ -7,7 +6,7 @@ namespace MageOS\CatalogDataAI\Api;
 interface RequestInterface
 {
     /**
-     * Retrieve products id.
+     * Retrieve product id.
      * @return int
      */
     public function getId(): int;
@@ -17,4 +16,10 @@ interface RequestInterface
      * @return bool
      */
     public function getOverwrite(): bool;
+
+    /**
+     * Retrieve store id.
+     * @return int
+     */
+    public function getStoreId(): int;
 }

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -13,9 +13,9 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Ui\Component\MassAction\Filter;
 use MageOS\CatalogDataAI\Model\Config;
-use Magento\Store\Model\StoreManagerInterface;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
 class MassEnrich extends Action implements HttpPostActionInterface

--- a/Controller/Adminhtml/Product/MassEnrich.php
+++ b/Controller/Adminhtml/Product/MassEnrich.php
@@ -15,6 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Ui\Component\MassAction\Filter;
 use MageOS\CatalogDataAI\Model\Config;
+use Magento\Store\Model\StoreManagerInterface;
 use MageOS\CatalogDataAI\Model\Product\Publisher;
 
 class MassEnrich extends Action implements HttpPostActionInterface
@@ -27,6 +28,7 @@ class MassEnrich extends Action implements HttpPostActionInterface
         private readonly Config                     $config,
         private readonly Publisher                  $publisher,
         private readonly ProductRepositoryInterface $productRepository,
+        private readonly StoreManagerInterface $storeManager,
     ) {
         parent::__construct($context);
     }
@@ -42,11 +44,12 @@ class MassEnrich extends Action implements HttpPostActionInterface
         $collection = $this->filter->getCollection($this->collectionFactory->create());
 
         $productEnriched = 0;
+        $storeId = (int)$this->storeManager->getStore()->getId();
         if ($this->config->isEnabled()) {
             /** @var Product $product */
             foreach ($collection->getItems() as $product) {
                 //@TODO: we hit rate limit, change to batching the request
-                $this->publisher->execute($product->getId(), $this->overwrite);
+                $this->publisher->execute($product->getId(), $this->overwrite, $storeId);
                 $productEnriched++;
             }
 

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -28,6 +28,21 @@ class Config
 
     private array $attributePromptsMap = [];
 
+    private const LOCALE_LANGUAGE_MAP = [
+        'af' => 'Afrikaans', 'ar' => 'Arabic', 'bg' => 'Bulgarian', 'bn' => 'Bengali',
+        'ca' => 'Catalan', 'cs' => 'Czech', 'cy' => 'Welsh', 'da' => 'Danish',
+        'de' => 'German', 'el' => 'Greek', 'en' => 'English', 'es' => 'Spanish',
+        'et' => 'Estonian', 'fa' => 'Persian', 'fi' => 'Finnish', 'fr' => 'French',
+        'gl' => 'Galician', 'he' => 'Hebrew', 'hi' => 'Hindi', 'hr' => 'Croatian',
+        'hu' => 'Hungarian', 'id' => 'Indonesian', 'it' => 'Italian', 'ja' => 'Japanese',
+        'ka' => 'Georgian', 'ko' => 'Korean', 'lt' => 'Lithuanian', 'lv' => 'Latvian',
+        'mk' => 'Macedonian', 'ms' => 'Malay', 'nb' => 'Norwegian', 'nl' => 'Dutch',
+        'pl' => 'Polish', 'pt' => 'Portuguese', 'ro' => 'Romanian', 'ru' => 'Russian',
+        'sk' => 'Slovak', 'sl' => 'Slovenian', 'sq' => 'Albanian', 'sr' => 'Serbian',
+        'sv' => 'Swedish', 'th' => 'Thai', 'tr' => 'Turkish', 'uk' => 'Ukrainian',
+        'vi' => 'Vietnamese', 'zh' => 'Chinese',
+    ];
+
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly Json $json
@@ -109,11 +124,27 @@ class Config
         return $this->isEnabled() && $this->getApiKey() && $product->isObjectNew();
     }
 
-    public function getSystemPrompt(): mixed
+    public function getSystemPrompt(): string
     {
-        return $this->scopeConfig->getValue(
-            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT
+        $basePrompt = (string)$this->scopeConfig->getValue(
+            self::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
+
+        $locale = $this->scopeConfig->getValue(
+            'general/locale/code',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+
+        if ($locale) {
+            $langCode = substr($locale, 0, 2);
+            $language = self::LOCALE_LANGUAGE_MAP[$langCode] ?? null;
+            if ($language && $langCode !== 'en') {
+                $basePrompt = 'Respond in ' . $language . '. ' . $basePrompt;
+            }
+        }
+
+        return $basePrompt;
     }
 
     public function getTemperature(): float

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/Product/Consumer.php
+++ b/Model/Product/Consumer.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -7,27 +6,23 @@ namespace MageOS\CatalogDataAI\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\Store\Model\StoreManagerInterface;
 
-/**
- * Class Consumer
- * @package Gaiterjones\RabbitMQ\MessageQueues\Product
- */
 class Consumer
 {
-    /**
-     * Consumer constructor.
-     */
     public function __construct(
-        private readonly Enricher          $enricher,
-        private readonly ProductRepository $productRepository,
+        private readonly Enricher              $enricher,
+        private readonly ProductRepository     $productRepository,
         private readonly StoreManagerInterface $storeManager
     ) {
     }
 
     public function execute(Request $request): void
     {
-        // @TODO: enrich for all stores if different value or language
-        $this->storeManager->setCurrentStore(0);
-        $product = $this->productRepository->getById($request->getId());
+        $this->storeManager->setCurrentStore($request->getStoreId());
+        $product = $this->productRepository->getById(
+            $request->getId(),
+            false,
+            $request->getStoreId()
+        );
         $product->setData('mageos_catalogai_overwrite', $request->getOverwrite());
         $this->enricher->execute($product);
 
@@ -35,5 +30,4 @@ class Consumer
             $this->productRepository->save($product);
         }
     }
-
 }

--- a/Model/Product/Publisher.php
+++ b/Model/Product/Publisher.php
@@ -19,15 +19,12 @@ class Publisher
     ) {
     }
 
-    /**
-     * @param int|string $productId
-     * @param bool $overwrite
-     */
-    public function execute(int|string $productId, bool $overwrite = false): void
+    public function execute(int|string $productId, bool $overwrite = false, int $storeId = 0): void
     {
         $request = $this->requestFactory->create([
             'id' => (int)$productId,
             'overwrite' => $overwrite,
+            'storeId' => $storeId,
         ]);
         $this->publisher->publish(self::TOPIC_NAME, $request);
     }

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -13,23 +12,23 @@ class Request implements RequestInterface
 {
     public function __construct(
         private readonly int $id,
-        private readonly bool $overwrite
+        private readonly bool $overwrite,
+        private readonly int $storeId = 0
     ) {
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOverwrite(): bool
     {
         return $this->overwrite;
+    }
+
+    public function getStoreId(): int
+    {
+        return $this->storeId;
     }
 }

--- a/Model/Product/Request.php
+++ b/Model/Product/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -28,7 +28,11 @@ class SaveAfter implements ObserverInterface
         $this->persistDeferredEnrichments($product);
 
         if ($this->config->canEnrich($product) && $this->config->isAsync()) {
-            $this->publisher->execute($product->getId(), false);
+            $this->publisher->execute(
+                $product->getId(),
+                false,
+                (int)$product->getStoreId()
+            );
         }
     }
 

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -178,12 +178,49 @@ class ConfigTest extends TestCase
 
     public function testGetSystemPrompt(): void
     {
-        $this->scopeConfig->expects($this->once())
-            ->method('getValue')
-            ->with(Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT)
-            ->willReturn('You are a helpful assistant');
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'You are a helpful assistant'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'en_US'],
+            ]);
 
         $this->assertSame('You are a helpful assistant', $this->config->getSystemPrompt());
+    }
+
+    public function test_get_system_prompt_prepends_language_for_non_english_locale(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'fr_FR'],
+            ]);
+
+        $result = $this->config->getSystemPrompt();
+
+        $this->assertStringContainsString('Respond in French', $result);
+        $this->assertStringContainsString('Be a content generator.', $result);
+    }
+
+    public function test_get_system_prompt_skips_language_prefix_for_english_locale(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'en_US'],
+            ]);
+
+        $this->assertSame('Be a content generator.', $this->config->getSystemPrompt());
+    }
+
+    public function test_get_system_prompt_handles_unknown_locale_gracefully(): void
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                [Config::XML_PATH_OPENAI_API_ADVANCED_SYSTEM_PROMPT, ScopeInterface::SCOPE_STORE, null, 'Be a content generator.'],
+                ['general/locale/code', ScopeInterface::SCOPE_STORE, null, 'xx_YY'],
+            ]);
+
+        $this->assertSame('Be a content generator.', $this->config->getSystemPrompt());
     }
 
     public function testGetApiMaxTokens(): void

--- a/Test/Unit/Model/Product/PublisherTest.php
+++ b/Test/Unit/Model/Product/PublisherTest.php
@@ -42,6 +42,7 @@ class PublisherTest extends TestCase
             ->with([
                 'id' => $productId,
                 'overwrite' => $overwrite,
+                'storeId' => 0,
             ])
             ->willReturn($request);
 
@@ -80,6 +81,7 @@ class PublisherTest extends TestCase
             ->with([
                 'id' => $productId,
                 'overwrite' => false,
+                'storeId' => 0,
             ])
             ->willReturn($request);
 
@@ -102,6 +104,7 @@ class PublisherTest extends TestCase
             ->with([
                 'id' => 42,
                 'overwrite' => $overwrite,
+                'storeId' => 0,
             ])
             ->willReturn($request);
 

--- a/Test/Unit/Model/Product/RequestTest.php
+++ b/Test/Unit/Model/Product/RequestTest.php
@@ -11,7 +11,7 @@ namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
 use MageOS\CatalogDataAI\Model\Product\Request;
 use PHPUnit\Framework\TestCase;
 
-class RequestTest extends TestCase
+final class RequestTest extends TestCase
 {
     public function testGetIdReturnsConstructorValue(): void
     {
@@ -29,5 +29,21 @@ class RequestTest extends TestCase
     {
         $request = new Request(1, false);
         $this->assertFalse($request->getOverwrite());
+    }
+
+    public function test_request_carries_store_id(): void
+    {
+        $request = new Request(42, true, 3);
+
+        $this->assertSame(42, $request->getId());
+        $this->assertTrue($request->getOverwrite());
+        $this->assertSame(3, $request->getStoreId());
+    }
+
+    public function test_store_id_defaults_to_zero(): void
+    {
+        $request = new Request(42, false);
+
+        $this->assertSame(0, $request->getStoreId());
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="MageOS_CatalogDataAI">
         <sequence>
             <module name="Magento_Catalog"/>
+            <module name="Magento_Store"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
## Summary

Fixes #12. Supersedes #53 (which was the Phase 2 bundle of locale + enrichment-flags; Ryan's #51 already covers the flags half, so this PR is just the locale half, cleanly rebased onto the post-merge main).

The enrichment pipeline now carries store context end-to-end, and the AI is automatically instructed to reply in the store's language.

## Changes

**Store context plumbing:**
- `Request` DTO gains a `storeId` field (defaults to 0 for backward compatibility with in-flight queue messages)
- `Publisher::execute` accepts and passes `storeId` to queue messages
- `Consumer` sets the correct store scope via `StoreManager::setCurrentStore` before loading the product
- `SaveAfter` observer forwards the product's store ID to the publisher
- `MassEnrich` controller forwards the current admin store scope

**Locale-aware system prompt:**
- `Config::getSystemPrompt()` now queries with `SCOPE_STORE`, reads `general/locale/code`, and prepends "Respond in {Language}. " for non-English locales
- Ships a `LOCALE_LANGUAGE_MAP` covering 46 ISO language codes
- English locales get the prompt unchanged; unknown locales fall through silently

**Module sequence:** added `Magento_Store` so DI resolution is ordered correctly.

## Test plan

- [x] Unit tests: 152 tests, 319 assertions, green on PHP 8.2/8.3/8.4 (via CI)
- [ ] On a non-English store (e.g., `fr_FR`), enrich a product: AI output should be in French
- [ ] On an English store, enrich a product: behavior identical to before
- [ ] Mass enrich from admin grid: products inherit the current admin store scope in the queue message
- [ ] Async mode: queue worker picks up the message, sets store scope before saving the product, output is correctly scoped

## What changed vs the original #53

- Dropped all `#48` enrichment-flags commits (Ryan's #51 covers the UI and #46 covers the log table)
- Dropped the Phase 1 commits that were superseded by Ryan's #38/#45 and the CI baseline
- Dropped the internal planning docs under `docs/plans/`
- Rebased cleanly onto current main; 11 files changed vs 36 before, +129/-39 lines