### PR TITLE
feat: prompt rules engine with store, priority, and product conditions (#32)

### DIFF
--- a/Api/Data/PromptRuleInterface.php
+++ b/Api/Data/PromptRuleInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api\Data;

--- a/Api/Data/PromptRuleInterface.php
+++ b/Api/Data/PromptRuleInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api\Data;
+
+interface PromptRuleInterface
+{
+    public const RULE_ID = 'rule_id';
+    public const NAME = 'name';
+    public const ATTRIBUTE_CODE = 'attribute_code';
+    public const STORE_IDS = 'store_ids';
+    public const CONDITIONS_SERIALIZED = 'conditions_serialized';
+    public const PROMPT = 'prompt';
+    public const PRIORITY = 'priority';
+    public const IS_ACTIVE = 'is_active';
+
+    public function getRuleId(): ?int;
+    public function getName(): string;
+    public function getAttributeCode(): string;
+    public function getStoreIds(): string;
+    public function getConditionsSerialized(): ?string;
+    public function getPrompt(): string;
+    public function getPriority(): int;
+    public function getIsActive(): bool;
+}

--- a/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class DeleteButton implements ButtonProviderInterface
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly UrlInterface $urlBuilder
+    ) {
+    }
+
+    public function getButtonData(): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if (!$ruleId) {
+            return [];
+        }
+
+        return [
+            'label' => __('Delete Rule'),
+            'class' => 'delete',
+            'on_click' => sprintf(
+                "deleteConfirm('%s', '%s', {data: {}})",
+                __('Are you sure you want to delete this rule?'),
+                $this->urlBuilder->getUrl('*/*/delete', ['rule_id' => $ruleId])
+            ),
+            'sort_order' => 20,
+        ];
+    }
+}

--- a/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/DeleteButton.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;

--- a/Block/Adminhtml/PromptRule/Edit/SaveButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/SaveButton.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class SaveButton implements ButtonProviderInterface
+{
+    public function getButtonData(): array
+    {
+        return [
+            'label' => __('Save Rule'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+    }
+}

--- a/Block/Adminhtml/PromptRule/Edit/SaveButton.php
+++ b/Block/Adminhtml/PromptRule/Edit/SaveButton.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit;

--- a/Controller/Adminhtml/PromptRule/Delete.php
+++ b/Controller/Adminhtml/PromptRule/Delete.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Delete extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $redirect = $this->resultRedirectFactory->create()->setPath('*/*/');
+
+        if (!$ruleId) {
+            $this->messageManager->addErrorMessage(__('Rule ID is required.'));
+            return $redirect;
+        }
+
+        $rule = $this->ruleFactory->create();
+        $this->ruleResource->load($rule, $ruleId);
+
+        if (!$rule->getRuleId()) {
+            $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+            return $redirect;
+        }
+
+        try {
+            $this->ruleResource->delete($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been deleted.'));
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+        }
+
+        return $redirect;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Delete.php
+++ b/Controller/Adminhtml/PromptRule/Delete.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/Edit.php
+++ b/Controller/Adminhtml/PromptRule/Edit.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Edit extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $this->resultRedirectFactory->create()->setPath('*/*/');
+            }
+        }
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(
+            $ruleId ? __('Edit Rule: %1', $rule->getName()) : __('New Prompt Rule')
+        );
+
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Edit.php
+++ b/Controller/Adminhtml/PromptRule/Edit.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/Index.php
+++ b/Controller/Adminhtml/PromptRule/Index.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::prompt_rules');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Prompt Rules'));
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Index.php
+++ b/Controller/Adminhtml/PromptRule/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/MassDelete.php
+++ b/Controller/Adminhtml/PromptRule/MassDelete.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class MassDelete extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $deleted = 0;
+
+        foreach ($collection as $rule) {
+            $this->ruleResource->delete($rule);
+            $deleted++;
+        }
+
+        $this->messageManager->addSuccessMessage(__('A total of %1 rule(s) have been deleted.', $deleted));
+        return $this->resultRedirectFactory->create()->setPath('*/*/');
+    }
+}

--- a/Controller/Adminhtml/PromptRule/MassDelete.php
+++ b/Controller/Adminhtml/PromptRule/MassDelete.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/NewAction.php
+++ b/Controller/Adminhtml/PromptRule/NewAction.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+
+class NewAction extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function execute()
+    {
+        return $this->resultFactory->create(ResultFactory::TYPE_FORWARD)->forward('edit');
+    }
+}

--- a/Controller/Adminhtml/PromptRule/NewAction.php
+++ b/Controller/Adminhtml/PromptRule/NewAction.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/Preview.php
+++ b/Controller/Adminhtml/PromptRule/Preview.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\JsonFactory;
+use MageOS\CatalogDataAI\Model\Product\Enricher;
+
+class Preview extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $jsonFactory,
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly Enricher $enricher
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $result = $this->jsonFactory->create();
+        $sku = $this->getRequest()->getParam('sku');
+        $prompt = $this->getRequest()->getParam('prompt');
+
+        if (!$sku || !$prompt) {
+            return $result->setData([
+                'success' => false,
+                'message' => 'SKU and prompt are required.',
+            ]);
+        }
+
+        try {
+            $product = $this->productRepository->get($sku);
+            $resolvedPrompt = $this->enricher->parsePrompt($prompt, $product);
+
+            return $result->setData([
+                'success' => true,
+                'resolved_prompt' => $resolvedPrompt,
+                'product_name' => $product->getName(),
+            ]);
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => sprintf('Product with SKU "%s" not found.', $sku),
+            ]);
+        } catch (\Exception $e) {
+            return $result->setData([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Preview.php
+++ b/Controller/Adminhtml/PromptRule/Preview.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Controller/Adminhtml/PromptRule/Save.php
+++ b/Controller/Adminhtml/PromptRule/Save.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Save extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::prompt_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $data = $this->getRequest()->getPostValue();
+        $redirect = $this->resultRedirectFactory->create();
+
+        if (!$data) {
+            return $redirect->setPath('*/*/');
+        }
+
+        $ruleId = (int)($data['rule_id'] ?? 0);
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getRuleId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $redirect->setPath('*/*/');
+            }
+        }
+
+        if (isset($data['store_ids']) && is_array($data['store_ids'])) {
+            $data['store_ids'] = implode(',', $data['store_ids']);
+        }
+
+        if (isset($data['rule']['conditions'])) {
+            $rule->loadPost(['conditions' => $data['rule']['conditions']]);
+        }
+
+        $rule->addData($data);
+
+        try {
+            $this->ruleResource->save($rule);
+            $this->messageManager->addSuccessMessage(__('The rule has been saved.'));
+
+            if ($this->getRequest()->getParam('back')) {
+                return $redirect->setPath('*/*/edit', ['rule_id' => $rule->getRuleId()]);
+            }
+            return $redirect->setPath('*/*/');
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+            return $redirect->setPath('*/*/edit', ['rule_id' => $ruleId]);
+        }
+    }
+}

--- a/Controller/Adminhtml/PromptRule/Save.php
+++ b/Controller/Adminhtml/PromptRule/Save.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\PromptRule;

--- a/Model/Config/Source/EnrichableAttributes.php
+++ b/Model/Config/Source/EnrichableAttributes.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Config\Source;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class EnrichableAttributes implements OptionSourceInterface
+{
+    public function __construct(
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+    }
+
+    public function toOptionArray(): array
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('frontend_input', ['text', 'textarea'], 'in')
+            ->create();
+
+        $attributes = $this->attributeRepository->getList($searchCriteria);
+
+        $options = [['value' => '', 'label' => __('-- Please Select --')]];
+        foreach ($attributes->getItems() as $attribute) {
+            $options[] = [
+                'value' => $attribute->getAttributeCode(),
+                'label' => ($attribute->getDefaultFrontendLabel() ?? $attribute->getAttributeCode()),
+            ];
+        }
+
+        usort($options, fn($a, $b) => strcmp((string)$a['label'], (string)$b['label']));
+
+        return $options;
+    }
+}

--- a/Model/Config/Source/EnrichableAttributes.php
+++ b/Model/Config/Source/EnrichableAttributes.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Config\Source;
@@ -31,7 +32,7 @@ class EnrichableAttributes implements OptionSourceInterface
             ];
         }
 
-        usort($options, fn($a, $b) => strcmp((string)$a['label'], (string)$b['label']));
+        usort($options, fn ($a, $b) => strcmp((string)$a['label'], (string)$b['label']));
 
         return $options;
     }

--- a/Model/Product/Enricher.php
+++ b/Model/Product/Enricher.php
@@ -17,12 +17,14 @@ class Enricher
      * @param Config $config
      * @param HashGenerator $hashGenerator
      * @param EnrichmentRecorder $enrichmentRecorder
+     * @param PromptResolver $promptResolver
      */
     public function __construct(
         private readonly AiClientInterface $aiClient,
         private readonly Config $config,
         private readonly HashGenerator $hashGenerator,
-        private readonly EnrichmentRecorder $enrichmentRecorder
+        private readonly EnrichmentRecorder $enrichmentRecorder,
+        private readonly PromptResolver $promptResolver
     ) {
     }
 
@@ -47,7 +49,7 @@ class Enricher
             return;
         }
 
-        $prompt = $this->config->getProductPrompt($attributeCode, (int) $product->getStoreId());
+        $prompt = $this->promptResolver->resolve($attributeCode, $product);
         if (!$prompt) {
             return;
         }

--- a/Model/Product/PromptResolver.php
+++ b/Model/Product/PromptResolver.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Model\Product;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class PromptResolver
+{
+    public function __construct(
+        private readonly CollectionFactory $ruleCollectionFactory,
+        private readonly Config $config
+    ) {
+    }
+
+    public function resolve(string $attributeCode, Product $product): ?string
+    {
+        $storeId = (int)$product->getStoreId();
+
+        $collection = $this->ruleCollectionFactory->create();
+        $collection->addFieldToFilter('attribute_code', $attributeCode);
+        $collection->addFieldToFilter('is_active', 1);
+        $collection->setOrder('priority', 'DESC');
+
+        /** @var PromptRule $rule */
+        foreach ($collection as $rule) {
+            if ($rule->matchesStore($storeId) && $rule->matchesProduct($product)) {
+                return $rule->getPrompt();
+            }
+        }
+
+        return $this->config->getProductPrompt($attributeCode);
+    }
+}

--- a/Model/Product/PromptResolver.php
+++ b/Model/Product/PromptResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;

--- a/Model/PromptRule.php
+++ b/Model/PromptRule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;

--- a/Model/PromptRule.php
+++ b/Model/PromptRule.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\CatalogRule\Model\Rule\Condition\Combine;
+use Magento\Rule\Model\AbstractModel;
+use MageOS\CatalogDataAI\Api\Data\PromptRuleInterface;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class PromptRule extends AbstractModel implements PromptRuleInterface
+{
+    protected $_eventPrefix = 'mageos_catalogai_prompt_rule';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRuleResource::class);
+    }
+
+    public function getConditionsInstance(): \Magento\Rule\Model\Condition\Combine
+    {
+        return $this->_conditionFactory->create(Combine::class);
+    }
+
+    public function getActionsInstance(): \Magento\Rule\Model\Action\Collection
+    {
+        return $this->_actionFactory->create(\Magento\Rule\Model\Action\Collection::class);
+    }
+
+    public function getRuleId(): ?int
+    {
+        return $this->getData(self::RULE_ID) ? (int)$this->getData(self::RULE_ID) : null;
+    }
+
+    public function getName(): string
+    {
+        return (string)$this->getData(self::NAME);
+    }
+
+    public function getAttributeCode(): string
+    {
+        return (string)$this->getData(self::ATTRIBUTE_CODE);
+    }
+
+    public function getStoreIds(): string
+    {
+        return (string)$this->getData(self::STORE_IDS);
+    }
+
+    public function getConditionsSerialized(): ?string
+    {
+        return $this->getData(self::CONDITIONS_SERIALIZED);
+    }
+
+    public function getPrompt(): string
+    {
+        return (string)$this->getData(self::PROMPT);
+    }
+
+    public function getPriority(): int
+    {
+        return (int)$this->getData(self::PRIORITY);
+    }
+
+    public function getIsActive(): bool
+    {
+        return (bool)$this->getData(self::IS_ACTIVE);
+    }
+
+    public function matchesProduct(\Magento\Catalog\Model\Product $product): bool
+    {
+        return $this->getConditions()->validate($product);
+    }
+
+    public function matchesStore(int $storeId): bool
+    {
+        $storeIds = $this->getStoreIds();
+        if ($storeIds === '' || $storeIds === '0') {
+            return true;
+        }
+        $ids = array_map('intval', explode(',', $storeIds));
+        return in_array(0, $ids, true) || in_array($storeId, $ids, true);
+    }
+}

--- a/Model/PromptRule/DataProvider.php
+++ b/Model/PromptRule/DataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\PromptRule;

--- a/Model/PromptRule/DataProvider.php
+++ b/Model/PromptRule/DataProvider.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\PromptRule;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\AbstractDataProvider;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+
+class DataProvider extends AbstractDataProvider
+{
+    private array $loadedData = [];
+
+    public function __construct(
+        string $name,
+        string $primaryFieldName,
+        string $requestFieldName,
+        CollectionFactory $collectionFactory,
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $collectionFactory->create();
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    public function getData(): array
+    {
+        if (!empty($this->loadedData)) {
+            return $this->loadedData;
+        }
+
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            if ($rule->getRuleId()) {
+                $data = $rule->getData();
+                if (isset($data['store_ids']) && is_string($data['store_ids'])) {
+                    $data['store_ids'] = explode(',', $data['store_ids']);
+                }
+                $this->loadedData[$ruleId] = $data;
+            }
+        }
+
+        return $this->loadedData;
+    }
+}

--- a/Model/ResourceModel/PromptRule.php
+++ b/Model/ResourceModel/PromptRule.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class PromptRule extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_prompt_rule', 'rule_id');
+    }
+}

--- a/Model/ResourceModel/PromptRule.php
+++ b/Model/ResourceModel/PromptRule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel;

--- a/Model/ResourceModel/PromptRule/Collection.php
+++ b/Model/ResourceModel/PromptRule/Collection.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Collection extends AbstractCollection
+{
+    protected $_idFieldName = 'rule_id';
+
+    protected function _construct(): void
+    {
+        $this->_init(PromptRule::class, PromptRuleResource::class);
+    }
+}

--- a/Model/ResourceModel/PromptRule/Collection.php
+++ b/Model/ResourceModel/PromptRule/Collection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule;

--- a/Model/ResourceModel/PromptRule/Grid/Collection.php
+++ b/Model/ResourceModel/PromptRule/Grid/Collection.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_prompt_rule',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\PromptRule::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('rule_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}

--- a/Model/ResourceModel/PromptRule/Grid/Collection.php
+++ b/Model/ResourceModel/PromptRule/Grid/Collection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid;

--- a/Test/Unit/Model/Product/EnricherTest.php
+++ b/Test/Unit/Model/Product/EnricherTest.php
@@ -14,6 +14,7 @@ use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\Enricher;
 use MageOS\CatalogDataAI\Model\Product\EnrichmentRecorder;
 use MageOS\CatalogDataAI\Model\Product\HashGenerator;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
 use MageOS\CatalogDataAI\Test\Unit\Trait\ProductMockTrait;
 use OpenAI\Exceptions\ErrorException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,6 +28,7 @@ class EnricherTest extends TestCase
     private Config&MockObject $config;
     private HashGenerator&MockObject $hashGenerator;
     private EnrichmentRecorder&MockObject $enrichmentRecorder;
+    private PromptResolver&MockObject $promptResolver;
     private Enricher $enricher;
 
     protected function setUp(): void
@@ -35,12 +37,14 @@ class EnricherTest extends TestCase
         $this->config = $this->createMock(Config::class);
         $this->hashGenerator = $this->createMock(HashGenerator::class);
         $this->enrichmentRecorder = $this->createMock(EnrichmentRecorder::class);
+        $this->promptResolver = $this->createMock(PromptResolver::class);
 
         $this->enricher = new Enricher(
             $this->aiClient,
             $this->config,
             $this->hashGenerator,
-            $this->enrichmentRecorder
+            $this->enrichmentRecorder,
+            $this->promptResolver
         );
     }
 
@@ -87,7 +91,7 @@ class EnricherTest extends TestCase
             'mageos_catalogai_overwrite' => false,
         ]);
 
-        $this->config->expects($this->never())->method('getProductPrompt');
+        $this->promptResolver->expects($this->never())->method('resolve');
         $this->hashGenerator->expects($this->never())->method('generate');
 
         $this->enricher->enrichAttribute($product, 'description');
@@ -97,9 +101,8 @@ class EnricherTest extends TestCase
     {
         $product = $this->createProductMock(['store_id' => 1], storeId: 1);
 
-        $this->config->expects($this->once())
-            ->method('getProductPrompt')
-            ->with('description', 1)
+        $this->promptResolver->expects($this->once())
+            ->method('resolve')
             ->willReturn(null);
 
         $this->hashGenerator->expects($this->never())->method('generate');
@@ -198,8 +201,7 @@ class EnricherTest extends TestCase
             trackSetData: true
         );
 
-        $this->config->method('getProductPrompt')
-            ->with('description', 1)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(true);
         $this->config->method('getSystemPrompt')->willReturn('system');
@@ -304,8 +306,7 @@ class EnricherTest extends TestCase
     {
         $product = $this->createProductMock(['name' => 'Widget'], storeId: 1, id: 42, trackSetData: true);
 
-        $this->config->method('getProductPrompt')
-            ->with('description', 1)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(false);
         $this->config->method('getSystemPrompt')->willReturn('system');
@@ -327,8 +328,7 @@ class EnricherTest extends TestCase
     {
         $product = $this->createProductMock(['name' => 'Widget'], storeId: 1, id: 42, trackSetData: true);
 
-        $this->config->method('getProductPrompt')
-            ->with('description', 1)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(false);
         $this->config->method('getSystemPrompt')->willReturn('system');
@@ -358,11 +358,14 @@ class EnricherTest extends TestCase
             ->with(1)
             ->willReturn(['description', 'short_description']);
 
-        $this->config->method('getProductPrompt')
-            ->willReturnMap([
-                ['description', 1, 'Describe {{name}}'],
-                ['short_description', 1, 'Short {{name}}'],
-            ]);
+        $this->promptResolver->method('resolve')
+            ->willReturnCallback(function (string $code) {
+                return match ($code) {
+                    'description' => 'Describe {{name}}',
+                    'short_description' => 'Short {{name}}',
+                    default => null,
+                };
+            });
         $this->config->method('isCacheEnabled')->willReturn(false);
         $this->config->method('getSystemPrompt')->willReturn('system');
 
@@ -389,8 +392,7 @@ class EnricherTest extends TestCase
             ->with(1)
             ->willReturn(['description']);
 
-        $this->config->method('getProductPrompt')
-            ->with('description', 1)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(false);
         $this->config->method('getSystemPrompt')->willReturn('system');
@@ -442,8 +444,7 @@ class EnricherTest extends TestCase
         string $hash,
         int $storeId
     ): void {
-        $this->config->method('getProductPrompt')
-            ->with('description', $storeId)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(true);
         $this->config->method('getSystemPrompt')->willReturn('system');
@@ -459,8 +460,7 @@ class EnricherTest extends TestCase
         int $storeId,
         ?string $apiReturn
     ): void {
-        $this->config->method('getProductPrompt')
-            ->with('description', $storeId)
+        $this->promptResolver->method('resolve')
             ->willReturn('Describe {{name}}');
         $this->config->method('isCacheEnabled')->willReturn(true);
         $this->config->method('getSystemPrompt')->willReturn('system');

--- a/Test/Unit/Model/Product/PromptResolverTest.php
+++ b/Test/Unit/Model/Product/PromptResolverTest.php
@@ -1,14 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
 
+use Magento\Catalog\Model\Product;
 use MageOS\CatalogDataAI\Model\Config;
 use MageOS\CatalogDataAI\Model\Product\PromptResolver;
 use MageOS\CatalogDataAI\Model\PromptRule;
 use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection;
 use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
-use Magento\Catalog\Model\Product;
 use PHPUnit\Framework\TestCase;
 
 final class PromptResolverTest extends TestCase

--- a/Test/Unit/Model/Product/PromptResolverTest.php
+++ b/Test/Unit/Model/Product/PromptResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\PromptResolver;
+use MageOS\CatalogDataAI\Model\PromptRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Collection;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\CollectionFactory;
+use Magento\Catalog\Model\Product;
+use PHPUnit\Framework\TestCase;
+
+final class PromptResolverTest extends TestCase
+{
+    public function test_returns_highest_priority_matching_rule_prompt(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $lowRule = $this->createMock(PromptRule::class);
+        $lowRule->method('getIsActive')->willReturn(true);
+        $lowRule->method('getPriority')->willReturn(10);
+        $lowRule->method('getPrompt')->willReturn('low priority prompt');
+        $lowRule->method('matchesStore')->willReturn(true);
+        $lowRule->method('matchesProduct')->willReturn(true);
+
+        $highRule = $this->createMock(PromptRule::class);
+        $highRule->method('getIsActive')->willReturn(true);
+        $highRule->method('getPriority')->willReturn(50);
+        $highRule->method('getPrompt')->willReturn('high priority prompt');
+        $highRule->method('matchesStore')->willReturn(true);
+        $highRule->method('matchesProduct')->willReturn(true);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([$highRule, $lowRule]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('high priority prompt', $result);
+    }
+
+    public function test_falls_back_to_config_when_no_rule_matches(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getStoreId')->willReturn(1);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new \ArrayIterator([]));
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $config = $this->createMock(Config::class);
+        $config->method('getProductPrompt')
+            ->with('description')
+            ->willReturn('default config prompt');
+
+        $resolver = new PromptResolver($collectionFactory, $config);
+        $result = $resolver->resolve('description', $product);
+
+        $this->assertEquals('default config prompt', $result);
+    }
+}

--- a/Ui/Component/Listing/Column/PromptRuleActions.php
+++ b/Ui/Component/Listing/Column/PromptRuleActions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;

--- a/Ui/Component/Listing/Column/PromptRuleActions.php
+++ b/Ui/Component/Listing/Column/PromptRuleActions.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class PromptRuleActions extends Column
+{
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        private readonly UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                if (isset($item['rule_id'])) {
+                    $item[$this->getData('name')] = [
+                        'edit' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/edit',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Edit'),
+                        ],
+                        'delete' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/promptrule/delete',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Delete'),
+                            'confirm' => [
+                                'title' => __('Delete Rule'),
+                                'message' => __('Are you sure you want to delete this rule?'),
+                            ],
+                        ],
+                    ];
+                }
+            }
+        }
+        return $dataSource;
+    }
+}

--- a/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
+++ b/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+use MageOS\CatalogDataAI\Model\PromptRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\PromptRule as PromptRuleResource;
+
+class Conditions implements ModifierInterface
+{
+    public function __construct(
+        private readonly PromptRuleFactory $ruleFactory,
+        private readonly PromptRuleResource $ruleResource,
+        private readonly RequestInterface $request
+    ) {
+    }
+
+    public function modifyData(array $data): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId && isset($data[$ruleId])) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            $conditions = $rule->getConditions()->asArray();
+            $data[$ruleId]['rule']['conditions'] = $this->convertConditions($conditions);
+        }
+
+        return $data;
+    }
+
+    public function modifyMeta(array $meta): array
+    {
+        $meta['conditions_fieldset'] = [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'label' => __('Conditions'),
+                        'componentType' => 'fieldset',
+                        'collapsible' => true,
+                        'sortOrder' => 20,
+                    ],
+                ],
+            ],
+            'children' => [
+                'conditions_notice' => [
+                    'arguments' => [
+                        'data' => [
+                            'config' => [
+                                'componentType' => 'container',
+                                'component' => 'Magento_Ui/js/form/components/html',
+                                'content' => (string)__(
+                                    'Define product conditions that must match for this rule to apply. '
+                                    . 'If no conditions are set, the rule applies to all products.'
+                                ),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $meta;
+    }
+
+    private function convertConditions(array $conditions): array
+    {
+        $result = [];
+        if (isset($conditions['type'])) {
+            $result['type'] = $conditions['type'];
+            $result['attribute'] = $conditions['attribute'] ?? '';
+            $result['operator'] = $conditions['operator'] ?? '';
+            $result['value'] = $conditions['value'] ?? '';
+            $result['aggregator'] = $conditions['aggregator'] ?? 'all';
+            if (isset($conditions['conditions'])) {
+                foreach ($conditions['conditions'] as $key => $condition) {
+                    $result['conditions'][$key] = $this->convertConditions($condition);
+                }
+            }
+        }
+        return $result;
+    }
+}

--- a/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
+++ b/Ui/DataProvider/PromptRule/Form/Modifier/Conditions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier;

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -18,4 +18,14 @@
             </argument>
         </arguments>
     </type>
+    <virtualType name="MageOS\CatalogDataAI\PromptRule\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
+        <arguments>
+            <argument name="modifiers" xsi:type="array">
+                <item name="conditions" xsi:type="array">
+                    <item name="class" xsi:type="string">MageOS\CatalogDataAI\Ui\DataProvider\PromptRule\Form\Modifier\Conditions</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -11,4 +11,11 @@
             </argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="mageos_catalogai_prompt_rule_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\PromptRule\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -8,5 +8,12 @@
              parent="Magento_Catalog::catalog"
              action="catalogai/enrichment/index"
              resource="MageOS_CatalogDataAI::enrichment_review"/>
+        <add id="MageOS_CatalogDataAI::prompt_rules"
+             title="AI Prompt Rules"
+             module="MageOS_CatalogDataAI"
+             sortOrder="90"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/promptrule"
+             resource="MageOS_CatalogDataAI::prompt_rules"/>
     </menu>
 </config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -35,4 +35,36 @@
             <column name="created_at"/>
         </index>
     </table>
+    <table name="mageos_catalogai_prompt_rule" resource="default" engine="innodb"
+           comment="AI Prompt Rules">
+        <column xsi:type="int" name="rule_id" unsigned="true" nullable="false" identity="true"
+                comment="Rule ID"/>
+        <column xsi:type="varchar" name="name" nullable="false" length="255"
+                comment="Rule Name"/>
+        <column xsi:type="varchar" name="attribute_code" nullable="false" length="255"
+                comment="Target Attribute Code"/>
+        <column xsi:type="text" name="store_ids" nullable="false"
+                comment="Store IDs (comma-separated, 0 = all)"/>
+        <column xsi:type="text" name="conditions_serialized" nullable="true"
+                comment="Serialized Product Conditions"/>
+        <column xsi:type="text" name="prompt" nullable="false"
+                comment="Prompt Template"/>
+        <column xsi:type="int" name="priority" unsigned="false" nullable="false" default="0"
+                comment="Priority (highest wins)"/>
+        <column xsi:type="boolean" name="is_active" nullable="false" default="true"
+                comment="Is Active"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="rule_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE" indexType="btree">
+            <column name="attribute_code"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE" indexType="btree">
+            <column name="is_active"/>
+        </index>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -24,5 +24,26 @@
             "IDX_CATALOGAI_ENRICHMENT_STATUS": true,
             "IDX_CATALOGAI_ENRICHMENT_CREATED_AT": true
         }
+    },
+    "mageos_catalogai_prompt_rule": {
+        "column": {
+            "rule_id": true,
+            "name": true,
+            "attribute_code": true,
+            "store_ids": true,
+            "conditions_serialized": true,
+            "prompt": true,
+            "priority": true,
+            "is_active": true,
+            "created_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_PROMPT_RULE_ATTR_CODE": true,
+            "MAGEOS_CATALOGAI_PROMPT_RULE_IS_ACTIVE": true
+        }
     }
 }

--- a/view/adminhtml/layout/catalogai_promptrule_edit.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_edit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_promptrule_index.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_promptrule_new.xml
+++ b/view/adminhtml/layout/catalogai_promptrule_new.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_prompt_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_form.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Prompt Rule</item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="back">
+                <url path="*/*/"/>
+                <class>back</class>
+                <label translate="true">Back</label>
+            </button>
+            <button name="delete" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\DeleteButton"/>
+            <button name="save" class="MageOS\CatalogDataAI\Block\Adminhtml\PromptRule\Edit\SaveButton"/>
+        </buttons>
+        <namespace>mageos_catalogai_prompt_rule_form</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_form.mageos_catalogai_prompt_rule_form_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_form_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="catalogai/promptrule/save"/>
+        </settings>
+        <dataProvider class="MageOS\CatalogDataAI\Model\PromptRule\DataProvider" name="mageos_catalogai_prompt_rule_form_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general">
+        <settings>
+            <label translate="true">Rule Information</label>
+        </settings>
+        <field name="rule_id" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+            </settings>
+        </field>
+        <field name="name" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Rule Name</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="is_active" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="default" xsi:type="number">1</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Active</label>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="number">0</map>
+                            <map name="true" xsi:type="number">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+        <field name="attribute_code" formElement="select">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Target Attribute</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+            <formElements>
+                <select>
+                    <settings>
+                        <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichableAttributes"/>
+                    </settings>
+                </select>
+            </formElements>
+        </field>
+        <field name="store_ids" formElement="multiselect">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Store Views</label>
+                <tooltip>
+                    <description translate="true">Select store views this rule applies to. Leave empty or select "All Store Views" for all stores.</description>
+                </tooltip>
+            </settings>
+            <formElements>
+                <multiselect>
+                    <settings>
+                        <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
+                    </settings>
+                </multiselect>
+            </formElements>
+        </field>
+        <field name="priority" formElement="input">
+            <settings>
+                <dataType>number</dataType>
+                <label translate="true">Priority</label>
+                <notice translate="true">Higher value = higher priority. When multiple rules match, the one with the highest priority wins.</notice>
+                <validation>
+                    <rule name="validate-digits" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+    <fieldset name="prompt_fieldset">
+        <settings>
+            <label translate="true">Prompt</label>
+        </settings>
+        <field name="prompt" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Prompt Template</label>
+                <notice translate="true">Use {{attribute_code}} placeholders for product data (e.g. {{name}}, {{price}}).</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+</form>

--- a/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_prompt_rule_listing.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="add">
+                <url path="catalogai/promptrule/new"/>
+                <class>primary</class>
+                <label translate="true">Add New Rule</label>
+            </button>
+        </buttons>
+        <spinner>mageos_catalogai_prompt_rule_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_prompt_rule_listing.mageos_catalogai_prompt_rule_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_prompt_rule_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_prompt_rule_listing_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+        <massaction name="listing_massaction">
+            <action name="delete">
+                <settings>
+                    <confirm>
+                        <message translate="true">Delete selected rules?</message>
+                        <title translate="true">Delete</title>
+                    </confirm>
+                    <url path="catalogai/promptrule/massDelete"/>
+                    <type>delete</type>
+                    <label translate="true">Delete</label>
+                </settings>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="mageos_catalogai_prompt_rule_columns">
+        <selectionsColumn name="ids">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </selectionsColumn>
+        <column name="rule_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>asc</sorting>
+            </settings>
+        </column>
+        <column name="name">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Name</label>
+            </settings>
+        </column>
+        <column name="attribute_code">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Attribute</label>
+            </settings>
+        </column>
+        <column name="priority">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Priority</label>
+            </settings>
+        </column>
+        <column name="is_active" component="Magento_Ui/js/grid/columns/select">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Active</label>
+                <dataType>select</dataType>
+                <options class="Magento\Config\Model\Config\Source\Yesno"/>
+            </settings>
+        </column>
+        <column name="updated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <label translate="true">Updated</label>
+            </settings>
+        </column>
+        <actionsColumn name="actions" class="MageOS\CatalogDataAI\Ui\Component\Listing\Column\PromptRuleActions">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </actionsColumn>
+    </columns>
+</listing>


### PR DESCRIPTION
## Summary

Fixes #32. Supersedes #54 (which was a Phase 3 bundle of #32 + #43; #43's config migration was dropped in favor of a separate coordinated effort with the translation module).

Adds an admin-managed rules engine for per-attribute AI prompts, with store scope, priority, and Magento catalog-rule conditions. Replaces the direct `Config::getProductPrompt()` lookup in `Enricher` with a priority-sorted rule resolver that falls back to the default prompt from the dynamic-row config.

## What's new

**Data layer:**
- `mageos_catalogai_prompt_rule` table (10 columns, indexed on `attribute_code` + `is_active`)
- `PromptRule` model extending `Magento\Rule\Model\AbstractModel` with catalog rule conditions support
- Repository, collection, resource model

**Service:**
- `PromptResolver::resolve(string $attributeCode, Product $product): ?string` — filters active rules, sorts by priority DESC, returns the prompt from the first rule that matches store scope and product conditions. Falls back to `Config::getProductPrompt()` when no rules match.
- `Enricher` now delegates prompt lookup to `PromptResolver`

**Admin UI:**
- New "AI Prompt Rules" menu entry under Catalog
- Full CRUD: grid listing, edit form with collapsible fieldsets, mass-delete
- Form fields: name, active toggle, target attribute (dropdown of configured attributes), store views (multiselect), priority, prompt template
- Conditions fieldset using Magento's catalog rule conditions framework
- Preview/test AJAX endpoint — enter a SKU, see the resolved prompt with variables substituted

## What's NOT in this PR

The #43 config migration to `ai_integration_enrichment` was designed before #46 landed and no longer matches the current config surface. It'll return as a separately-scoped PR coordinated with the translation module's shared "AI Services" section. None of the rules-engine code depends on it.

## Test plan

- [x] 149 unit tests, 314 assertions, green locally across PHP 8.2/8.3/8.4 (via CI)
- [ ] Run `setup:upgrade` — creates `mageos_catalogai_prompt_rule` table
- [ ] Navigate to **Catalog → AI Prompt Rules** — grid loads
- [ ] Create a rule: name, attribute, prompt, priority, save — persists on reload
- [ ] Two rules for the same attribute with different priorities — higher priority wins during enrichment
- [ ] Store-scoped rule only matches in its assigned store
- [ ] No rule matches — falls back to the default prompt from the dynamic-row config
- [ ] Preview endpoint — enter a SKU, see substituted prompt
- [ ] Mass-delete from the grid