### PR TITLE
feat: structured attribute extraction with value mapping (#7)

### DIFF
--- a/Api/Data/ExtractionRuleInterface.php
+++ b/Api/Data/ExtractionRuleInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Api\Data;

--- a/Api/Data/ExtractionRuleInterface.php
+++ b/Api/Data/ExtractionRuleInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Api\Data;
+
+interface ExtractionRuleInterface
+{
+    public const RULE_ID = 'rule_id';
+    public const NAME = 'name';
+    public const SOURCE_ATTRIBUTES = 'source_attributes';
+    public const TARGET_ATTRIBUTE = 'target_attribute';
+    public const EXTRACTION_PROMPT = 'extraction_prompt';
+    public const VALUE_MAPPING = 'value_mapping';
+    public const CONDITIONS_SERIALIZED = 'conditions_serialized';
+    public const STORE_IDS = 'store_ids';
+    public const PRIORITY = 'priority';
+    public const IS_ACTIVE = 'is_active';
+}

--- a/Block/Adminhtml/ExtractionRule/Edit/DeleteButton.php
+++ b/Block/Adminhtml/ExtractionRule/Edit/DeleteButton.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class DeleteButton implements ButtonProviderInterface
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly UrlInterface $urlBuilder
+    ) {
+    }
+
+    public function getButtonData(): array
+    {
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if (!$ruleId) {
+            return [];
+        }
+
+        return [
+            'label' => __('Delete Rule'),
+            'class' => 'delete',
+            'on_click' => sprintf(
+                "deleteConfirm('%s', '%s', {data: {}})",
+                __('Are you sure you want to delete this rule?'),
+                $this->urlBuilder->getUrl('*/*/delete', ['rule_id' => $ruleId])
+            ),
+            'sort_order' => 20,
+        ];
+    }
+}

--- a/Block/Adminhtml/ExtractionRule/Edit/DeleteButton.php
+++ b/Block/Adminhtml/ExtractionRule/Edit/DeleteButton.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit;

--- a/Block/Adminhtml/ExtractionRule/Edit/SaveButton.php
+++ b/Block/Adminhtml/ExtractionRule/Edit/SaveButton.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit;

--- a/Block/Adminhtml/ExtractionRule/Edit/SaveButton.php
+++ b/Block/Adminhtml/ExtractionRule/Edit/SaveButton.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class SaveButton implements ButtonProviderInterface
+{
+    public function getButtonData(): array
+    {
+        return [
+            'label' => __('Save Rule'),
+            'class' => 'save primary',
+            'data_attribute' => [
+                'mage-init' => ['button' => ['event' => 'save']],
+                'form-role' => 'save',
+            ],
+            'sort_order' => 90,
+        ];
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/Delete.php
+++ b/Controller/Adminhtml/ExtractionRule/Delete.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;

--- a/Controller/Adminhtml/ExtractionRule/Delete.php
+++ b/Controller/Adminhtml/ExtractionRule/Delete.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\ExtractionRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+
+class Delete extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::extraction_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly ExtractionRuleFactory $ruleFactory,
+        private readonly ExtractionRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $redirect = $this->resultRedirectFactory->create()->setPath('*/*/');
+
+        if ($ruleId) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+            if ($rule->getId()) {
+                try {
+                    $this->ruleResource->delete($rule);
+                    $this->messageManager->addSuccessMessage(__('The rule has been deleted.'));
+                } catch (\Exception $e) {
+                    $this->messageManager->addErrorMessage($e->getMessage());
+                }
+            }
+        }
+
+        return $redirect;
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/Edit.php
+++ b/Controller/Adminhtml/ExtractionRule/Edit.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;

--- a/Controller/Adminhtml/ExtractionRule/Edit.php
+++ b/Controller/Adminhtml/ExtractionRule/Edit.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+use MageOS\CatalogDataAI\Model\ExtractionRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+
+class Edit extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::extraction_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory,
+        private readonly ExtractionRuleFactory $ruleFactory,
+        private readonly ExtractionRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $ruleId = (int)$this->getRequest()->getParam('rule_id');
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $this->resultRedirectFactory->create()->setPath('*/*/');
+            }
+        }
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::extraction_rules');
+        $resultPage->getConfig()->getTitle()->prepend(
+            $ruleId ? __('Edit Extraction Rule: %1', $rule->getData('name')) : __('New Extraction Rule')
+        );
+
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/Index.php
+++ b/Controller/Adminhtml/ExtractionRule/Index.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::extraction_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('MageOS_CatalogDataAI::extraction_rules');
+        $resultPage->getConfig()->getTitle()->prepend(__('AI Extraction Rules'));
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/Index.php
+++ b/Controller/Adminhtml/ExtractionRule/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;

--- a/Controller/Adminhtml/ExtractionRule/NewAction.php
+++ b/Controller/Adminhtml/ExtractionRule/NewAction.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+
+class NewAction extends Action implements HttpGetActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::extraction_rules';
+
+    public function execute()
+    {
+        return $this->resultFactory->create(ResultFactory::TYPE_FORWARD)->forward('edit');
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/NewAction.php
+++ b/Controller/Adminhtml/ExtractionRule/NewAction.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;

--- a/Controller/Adminhtml/ExtractionRule/Save.php
+++ b/Controller/Adminhtml/ExtractionRule/Save.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use MageOS\CatalogDataAI\Model\ExtractionRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+
+class Save extends Action implements HttpPostActionInterface
+{
+    public const ADMIN_RESOURCE = 'MageOS_CatalogDataAI::extraction_rules';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly ExtractionRuleFactory $ruleFactory,
+        private readonly ExtractionRuleResource $ruleResource
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $data = $this->getRequest()->getPostValue();
+        $redirect = $this->resultRedirectFactory->create();
+
+        if (!$data) {
+            return $redirect->setPath('*/*/');
+        }
+
+        $ruleId = (int)($data['rule_id'] ?? 0);
+        $rule = $this->ruleFactory->create();
+
+        if ($ruleId) {
+            $this->ruleResource->load($rule, $ruleId);
+            if (!$rule->getId()) {
+                $this->messageManager->addErrorMessage(__('This rule no longer exists.'));
+                return $redirect->setPath('*/*/');
+            }
+        }
+
+        if (isset($data['store_ids']) && is_array($data['store_ids'])) {
+            $data['store_ids'] = implode(',', $data['store_ids']);
+        }
+
+        if (isset($data['source_attributes']) && is_array($data['source_attributes'])) {
+            $data['source_attributes'] = implode(',', $data['source_attributes']);
+        }
+
+        if (isset($data['rule']['conditions'])) {
+            $rule->loadPost(['conditions' => $data['rule']['conditions']]);
+        }
+
+        $rule->addData($data);
+
+        try {
+            $this->ruleResource->save($rule);
+            $this->messageManager->addSuccessMessage(__('The extraction rule has been saved.'));
+
+            if ($this->getRequest()->getParam('back')) {
+                return $redirect->setPath('*/*/edit', ['rule_id' => $rule->getId()]);
+            }
+            return $redirect->setPath('*/*/');
+        } catch (\Exception $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
+            return $redirect->setPath('*/*/edit', ['rule_id' => $ruleId]);
+        }
+    }
+}

--- a/Controller/Adminhtml/ExtractionRule/Save.php
+++ b/Controller/Adminhtml/ExtractionRule/Save.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\ExtractionRule;

--- a/Controller/Adminhtml/Product/MassExtract.php
+++ b/Controller/Adminhtml/Product/MassExtract.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;

--- a/Controller/Adminhtml/Product/MassExtract.php
+++ b/Controller/Adminhtml/Product/MassExtract.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Controller\Adminhtml\Product;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Ui\Component\MassAction\Filter;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\Product\Publisher;
+
+class MassExtract extends Action implements HttpPostActionInterface
+{
+    public function __construct(
+        Context $context,
+        private readonly Filter $filter,
+        private readonly CollectionFactory $collectionFactory,
+        private readonly Config $config,
+        private readonly Publisher $publisher,
+        private readonly StoreManagerInterface $storeManager,
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $scheduled = 0;
+
+        if ($this->config->isEnabled()) {
+            $storeId = (int)$this->storeManager->getStore()->getId();
+            foreach ($collection->getItems() as $product) {
+                $this->publisher->execute($product->getId(), false, $storeId);
+                $scheduled++;
+            }
+            $this->messageManager->addSuccessMessage(
+                __('A total of %1 product(s) are scheduled for attribute extraction.', $scheduled)
+            );
+        } else {
+            $this->messageManager->addErrorMessage(
+                __('Data enrichment is disabled. Please enable it in the configuration.')
+            );
+        }
+
+        return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath('catalog/*/index');
+    }
+}

--- a/Model/ExtractionRule.php
+++ b/Model/ExtractionRule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model;

--- a/Model/ExtractionRule.php
+++ b/Model/ExtractionRule.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model;
+
+use Magento\CatalogRule\Model\Rule\Condition\Combine;
+use Magento\Rule\Model\AbstractModel;
+use MageOS\CatalogDataAI\Api\Data\ExtractionRuleInterface;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+
+class ExtractionRule extends AbstractModel implements ExtractionRuleInterface
+{
+    protected $_eventPrefix = 'mageos_catalogai_extraction_rule';
+
+    protected function _construct(): void
+    {
+        $this->_init(ExtractionRuleResource::class);
+    }
+
+    public function getConditionsInstance(): \Magento\Rule\Model\Condition\Combine
+    {
+        return $this->_conditionFactory->create(Combine::class);
+    }
+
+    public function getActionsInstance(): \Magento\Rule\Model\Action\Collection
+    {
+        return $this->_actionFactory->create(\Magento\Rule\Model\Action\Collection::class);
+    }
+
+    public function getSourceAttributes(): array
+    {
+        $value = (string)$this->getData(self::SOURCE_ATTRIBUTES);
+        return $value ? array_map('trim', explode(',', $value)) : [];
+    }
+
+    public function getTargetAttribute(): string
+    {
+        return (string)$this->getData(self::TARGET_ATTRIBUTE);
+    }
+
+    public function getExtractionPrompt(): string
+    {
+        return (string)$this->getData(self::EXTRACTION_PROMPT);
+    }
+
+    public function getValueMapping(): array
+    {
+        $json = $this->getData(self::VALUE_MAPPING);
+        if (!$json) {
+            return [];
+        }
+        $decoded = json_decode($json, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function matchesProduct(\Magento\Catalog\Model\Product $product): bool
+    {
+        return $this->getConditions()->validate($product);
+    }
+
+    public function matchesStore(int $storeId): bool
+    {
+        $storeIds = (string)$this->getData(self::STORE_IDS);
+        if ($storeIds === '' || $storeIds === '0') {
+            return true;
+        }
+        $ids = array_map('intval', explode(',', $storeIds));
+        return in_array(0, $ids, true) || in_array($storeId, $ids, true);
+    }
+}

--- a/Model/ExtractionRule/DataProvider.php
+++ b/Model/ExtractionRule/DataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ExtractionRule;

--- a/Model/ExtractionRule/DataProvider.php
+++ b/Model/ExtractionRule/DataProvider.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ExtractionRule;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\AbstractDataProvider;
+use MageOS\CatalogDataAI\Model\ExtractionRuleFactory;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\CollectionFactory;
+
+class DataProvider extends AbstractDataProvider
+{
+    private array $loadedData = [];
+
+    public function __construct(
+        string $name,
+        string $primaryFieldName,
+        string $requestFieldName,
+        CollectionFactory $collectionFactory,
+        private readonly ExtractionRuleFactory $ruleFactory,
+        private readonly ExtractionRuleResource $ruleResource,
+        private readonly RequestInterface $request,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $collectionFactory->create();
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    public function getData(): array
+    {
+        if (!empty($this->loadedData)) {
+            return $this->loadedData;
+        }
+
+        $ruleId = (int)$this->request->getParam('rule_id');
+        if ($ruleId) {
+            $rule = $this->ruleFactory->create();
+            $this->ruleResource->load($rule, $ruleId);
+
+            if ($rule->getId()) {
+                $data = $rule->getData();
+                if (isset($data['store_ids']) && is_string($data['store_ids'])) {
+                    $data['store_ids'] = explode(',', $data['store_ids']);
+                }
+                if (isset($data['source_attributes']) && is_string($data['source_attributes'])) {
+                    $data['source_attributes'] = explode(',', $data['source_attributes']);
+                }
+                $this->loadedData[$ruleId] = $data;
+            }
+        }
+
+        return $this->loadedData;
+    }
+}

--- a/Model/Product/AttributeExtractor.php
+++ b/Model/Product/AttributeExtractor.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\Product;
@@ -138,13 +139,13 @@ class AttributeExtractor
             'messages' => [
                 [
                     'role' => 'developer',
-                    'content' => 'You are a data extraction assistant. Extract the requested value and return ONLY a JSON object with a "value" key. Example: {"value": "extracted data"}'
+                    'content' => 'You are a data extraction assistant. Extract the requested value and return ONLY a JSON object with a "value" key. Example: {"value": "extracted data"}',
                 ],
                 [
                     'role' => 'user',
-                    'content' => $prompt . "\n\nSource data:\n" . $sourceData
-                ]
-            ]
+                    'content' => $prompt . "\n\nSource data:\n" . $sourceData,
+                ],
+            ],
         ]);
 
         if (!$result = $response->choices[0]) {

--- a/Model/Product/AttributeExtractor.php
+++ b/Model/Product/AttributeExtractor.php
@@ -1,0 +1,228 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\Product;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use MageOS\CatalogDataAI\Model\Config;
+use MageOS\CatalogDataAI\Model\EnrichmentLog;
+use MageOS\CatalogDataAI\Model\ExtractionRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\CollectionFactory;
+use OpenAI\Client;
+use OpenAI\Factory;
+use Psr\Log\LoggerInterface;
+
+class AttributeExtractor
+{
+    private Client $client;
+
+    public function __construct(
+        private readonly Factory $clientFactory,
+        private readonly Config $config,
+        private readonly CollectionFactory $ruleCollectionFactory,
+        private readonly EnrichmentLogger $enrichmentLogger,
+        private readonly ProductAttributeRepositoryInterface $attributeRepository,
+        private readonly Enricher $enricher,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    private function getClient(): Client
+    {
+        if (!isset($this->client)) {
+            $this->client = $this->clientFactory
+                ->withOrganization($this->config->getOrganizationId())
+                ->withApiKey($this->config->getApiKey())
+                ->withProject($this->config->getProjectId())
+                ->make();
+        }
+
+        return $this->client;
+    }
+
+    public function execute(Product $product): void
+    {
+        $storeId = (int)$product->getStoreId();
+
+        $collection = $this->ruleCollectionFactory->create();
+        $collection->addFieldToFilter('is_active', 1);
+        $collection->setOrder('priority', 'DESC');
+
+        $processedTargets = [];
+
+        /** @var ExtractionRule $rule */
+        foreach ($collection as $rule) {
+            $target = $rule->getTargetAttribute();
+
+            if (isset($processedTargets[$target])) {
+                continue;
+            }
+
+            if (!$rule->matchesStore($storeId) || !$rule->matchesProduct($product)) {
+                continue;
+            }
+
+            $this->extractAttribute($product, $rule);
+            $processedTargets[$target] = true;
+        }
+    }
+
+    private function extractAttribute(Product $product, ExtractionRule $rule): void
+    {
+        $sourceData = $this->buildSourceData($product, $rule->getSourceAttributes());
+        if (!$sourceData) {
+            return;
+        }
+
+        $resolvedPrompt = $this->enricher->parsePrompt($rule->getExtractionPrompt(), $product);
+        $promptHash = hash('sha256', $resolvedPrompt . $sourceData);
+        $storeId = (int)$product->getStoreId();
+        $targetAttribute = $rule->getTargetAttribute();
+        $originalContent = (string)$product->getData($targetAttribute);
+
+        // Check cache
+        $cached = $this->enrichmentLogger->findByPromptHash($promptHash, $targetAttribute, $storeId);
+        if ($cached !== null) {
+            $extractedValue = $cached;
+        } else {
+            $extractedValue = $this->callOpenAI($resolvedPrompt, $sourceData);
+            if ($extractedValue === null) {
+                return;
+            }
+        }
+
+        // Map and validate
+        $finalValue = $this->mapAndValidate($extractedValue, $targetAttribute, $rule->getValueMapping());
+        if ($finalValue === null) {
+            $this->logger->warning(sprintf(
+                'Extraction validation failed for product %d, attribute %s: AI returned "%s"',
+                $product->getId(),
+                $targetAttribute,
+                $extractedValue
+            ));
+            return;
+        }
+
+        // Always pending_review for extractions
+        $this->enrichmentLogger->log(
+            (int)$product->getId(),
+            $targetAttribute,
+            $storeId,
+            (string)$finalValue,
+            $originalContent,
+            $promptHash,
+            EnrichmentLog::STATUS_PENDING_REVIEW
+        );
+    }
+
+    private function buildSourceData(Product $product, array $sourceAttributes): string
+    {
+        $parts = [];
+        foreach ($sourceAttributes as $code) {
+            $value = $product->getData($code);
+            if ($value) {
+                $parts[] = $code . ': ' . $value;
+            }
+        }
+        return implode("\n", $parts);
+    }
+
+    private function callOpenAI(string $prompt, string $sourceData): ?string
+    {
+        $response = $this->getClient()->chat()->create([
+            'model' => $this->config->getApiModel(),
+            'temperature' => 0,
+            'max_completion_tokens' => 256,
+            'response_format' => ['type' => 'json_object'],
+            'messages' => [
+                [
+                    'role' => 'developer',
+                    'content' => 'You are a data extraction assistant. Extract the requested value and return ONLY a JSON object with a "value" key. Example: {"value": "extracted data"}'
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $prompt . "\n\nSource data:\n" . $sourceData
+                ]
+            ]
+        ]);
+
+        if (!$result = $response->choices[0]) {
+            return null;
+        }
+
+        $content = $result->message?->content ?? '';
+        $decoded = json_decode($content, true);
+
+        $this->enricher->backoff($response->meta());
+
+        return isset($decoded['value']) ? (string)$decoded['value'] : null;
+    }
+
+    private function mapAndValidate(string $value, string $targetAttributeCode, array $valueMapping): ?string
+    {
+        try {
+            $attribute = $this->attributeRepository->get($targetAttributeCode);
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        $frontendInput = $attribute->getFrontendInput();
+
+        switch ($frontendInput) {
+            case 'select':
+            case 'multiselect':
+                if (!empty($valueMapping)) {
+                    return self::resolveMappedValue($value, $valueMapping);
+                }
+                $options = $attribute->getSource()->getAllOptions(false);
+                foreach ($options as $option) {
+                    if (strcasecmp((string)$option['label'], $value) === 0) {
+                        return (string)$option['value'];
+                    }
+                }
+                return null;
+
+            case 'boolean':
+                $lower = strtolower(trim($value));
+                if (in_array($lower, ['yes', 'true', '1'], true)) {
+                    return '1';
+                }
+                if (in_array($lower, ['no', 'false', '0'], true)) {
+                    return '0';
+                }
+                return null;
+
+            case 'price':
+            case 'weight':
+                return is_numeric($value) ? $value : null;
+
+            case 'text':
+            case 'textarea':
+                return $value;
+
+            default:
+                return $value;
+        }
+    }
+
+    public static function resolveMappedValue(string $aiOutput, array $mapping): ?string
+    {
+        // Exact match (case-insensitive)
+        foreach ($mapping as $label => $optionId) {
+            if (strcasecmp($label, $aiOutput) === 0) {
+                return (string)$optionId;
+            }
+        }
+
+        // Fuzzy: AI output is a substring of a mapping key (case-insensitive)
+        $lowerOutput = strtolower($aiOutput);
+        foreach ($mapping as $label => $optionId) {
+            if (str_contains(strtolower($label), $lowerOutput)) {
+                return (string)$optionId;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Model/ResourceModel/ExtractionRule.php
+++ b/Model/ResourceModel/ExtractionRule.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class ExtractionRule extends AbstractDb
+{
+    protected function _construct(): void
+    {
+        $this->_init('mageos_catalogai_extraction_rule', 'rule_id');
+    }
+}

--- a/Model/ResourceModel/ExtractionRule.php
+++ b/Model/ResourceModel/ExtractionRule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel;

--- a/Model/ResourceModel/ExtractionRule/Collection.php
+++ b/Model/ResourceModel/ExtractionRule/Collection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule;

--- a/Model/ResourceModel/ExtractionRule/Collection.php
+++ b/Model/ResourceModel/ExtractionRule/Collection.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use MageOS\CatalogDataAI\Model\ExtractionRule;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule as ExtractionRuleResource;
+
+class Collection extends AbstractCollection
+{
+    protected $_idFieldName = 'rule_id';
+
+    protected function _construct(): void
+    {
+        $this->_init(ExtractionRule::class, ExtractionRuleResource::class);
+    }
+}

--- a/Model/ResourceModel/ExtractionRule/Grid/Collection.php
+++ b/Model/ResourceModel/ExtractionRule/Grid/Collection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\Grid;

--- a/Model/ResourceModel/ExtractionRule/Grid/Collection.php
+++ b/Model/ResourceModel/ExtractionRule/Grid/Collection.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\Grid;
+
+use Magento\Framework\Api\Search\AggregationInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\Collection as BaseCollection;
+use Psr\Log\LoggerInterface;
+
+class Collection extends BaseCollection implements SearchResultInterface
+{
+    private AggregationInterface $aggregations;
+
+    public function __construct(
+        EntityFactoryInterface $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        string $mainTable = 'mageos_catalogai_extraction_rule',
+        string $resourceModel = \MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule::class,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+        $this->_mainTable = $mainTable;
+        $this->_setIdFieldName('rule_id');
+        $this->setModel(\Magento\Framework\View\Element\UiComponent\DataProvider\Document::class);
+    }
+
+    public function getAggregations(): AggregationInterface
+    {
+        return $this->aggregations;
+    }
+
+    public function setAggregations($aggregations): self
+    {
+        $this->aggregations = $aggregations;
+        return $this;
+    }
+
+    public function getSearchCriteria(): ?SearchCriteriaInterface
+    {
+        return null;
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->getSize();
+    }
+
+    public function setTotalCount($totalCount): self
+    {
+        return $this;
+    }
+
+    public function setItems(?array $items = null): self
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Model/Product/AttributeExtractorTest.php
+++ b/Test/Unit/Model/Product/AttributeExtractorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;

--- a/Test/Unit/Model/Product/AttributeExtractorTest.php
+++ b/Test/Unit/Model/Product/AttributeExtractorTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Test\Unit\Model\Product;
+
+use MageOS\CatalogDataAI\Model\Product\AttributeExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeExtractorTest extends TestCase
+{
+    public function test_resolve_mapped_value_exact_match(): void
+    {
+        $mapping = ['Red' => '42', 'Blue' => '43', 'Green' => '44'];
+        $result = AttributeExtractor::resolveMappedValue('Red', $mapping);
+        $this->assertEquals('42', $result);
+    }
+
+    public function test_resolve_mapped_value_case_insensitive(): void
+    {
+        $mapping = ['Red' => '42', 'Blue' => '43'];
+        $result = AttributeExtractor::resolveMappedValue('red', $mapping);
+        $this->assertEquals('42', $result);
+    }
+
+    public function test_resolve_mapped_value_fuzzy_match(): void
+    {
+        $mapping = ['Crimson Red' => '42', 'Ocean Blue' => '43'];
+        $result = AttributeExtractor::resolveMappedValue('crimson', $mapping);
+        $this->assertEquals('42', $result);
+    }
+
+    public function test_resolve_mapped_value_returns_null_on_no_match(): void
+    {
+        $mapping = ['Red' => '42', 'Blue' => '43'];
+        $result = AttributeExtractor::resolveMappedValue('Yellow', $mapping);
+        $this->assertNull($result);
+    }
+}

--- a/Ui/Component/Listing/Column/ExtractionRuleActions.php
+++ b/Ui/Component/Listing/Column/ExtractionRuleActions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;

--- a/Ui/Component/Listing/Column/ExtractionRuleActions.php
+++ b/Ui/Component/Listing/Column/ExtractionRuleActions.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace MageOS\CatalogDataAI\Ui\Component\Listing\Column;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class ExtractionRuleActions extends Column
+{
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        private readonly UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                if (isset($item['rule_id'])) {
+                    $item[$this->getData('name')] = [
+                        'edit' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/extractionrule/edit',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Edit'),
+                        ],
+                        'delete' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                'catalogai/extractionrule/delete',
+                                ['rule_id' => $item['rule_id']]
+                            ),
+                            'label' => __('Delete'),
+                            'confirm' => [
+                                'title' => __('Delete Rule'),
+                                'message' => __('Are you sure?'),
+                            ],
+                        ],
+                    ];
+                }
+            }
+        }
+        return $dataSource;
+    }
+}

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -5,6 +5,7 @@
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Catalog::catalog">
                     <resource id="MageOS_CatalogDataAI::enrichment_review" title="AI Enrichment Review" translate="title" sortOrder="35" />
+                    <resource id="MageOS_CatalogDataAI::extraction_rules" title="AI Extraction Rules" translate="title" sortOrder="36" />
                 </resource>
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -11,4 +11,11 @@
             </argument>
         </arguments>
     </virtualType>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="mageos_catalogai_extraction_rule_listing_data_source" xsi:type="string">MageOS\CatalogDataAI\Model\ResourceModel\ExtractionRule\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -8,5 +8,12 @@
              parent="Magento_Catalog::catalog"
              action="catalogai/enrichment/index"
              resource="MageOS_CatalogDataAI::enrichment_review"/>
+        <add id="MageOS_CatalogDataAI::extraction_rules"
+             title="AI Extraction Rules"
+             module="MageOS_CatalogDataAI"
+             sortOrder="92"
+             parent="Magento_Catalog::catalog"
+             action="catalogai/extractionrule"
+             resource="MageOS_CatalogDataAI::extraction_rules"/>
     </menu>
 </config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -35,4 +35,40 @@
             <column name="created_at"/>
         </index>
     </table>
+    <table name="mageos_catalogai_extraction_rule" resource="default" engine="innodb"
+           comment="AI Attribute Extraction Rules">
+        <column xsi:type="int" name="rule_id" unsigned="true" nullable="false" identity="true"
+                comment="Rule ID"/>
+        <column xsi:type="varchar" name="name" nullable="false" length="255"
+                comment="Rule Name"/>
+        <column xsi:type="varchar" name="source_attributes" nullable="false" length="1024"
+                comment="Source Attribute Codes (comma-separated)"/>
+        <column xsi:type="varchar" name="target_attribute" nullable="false" length="255"
+                comment="Target Attribute Code"/>
+        <column xsi:type="text" name="extraction_prompt" nullable="false"
+                comment="Extraction Prompt Template"/>
+        <column xsi:type="text" name="value_mapping" nullable="true"
+                comment="JSON Value Mapping (AI output to option IDs)"/>
+        <column xsi:type="text" name="conditions_serialized" nullable="true"
+                comment="Serialized Product Conditions"/>
+        <column xsi:type="text" name="store_ids" nullable="false"
+                comment="Store IDs (comma-separated, 0 = all)"/>
+        <column xsi:type="int" name="priority" unsigned="false" nullable="false" default="0"
+                comment="Priority (highest wins)"/>
+        <column xsi:type="boolean" name="is_active" nullable="false" default="true"
+                comment="Is Active"/>
+        <column xsi:type="timestamp" name="created_at" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+        <column xsi:type="timestamp" name="updated_at" nullable="false" default="CURRENT_TIMESTAMP"
+                on_update="true" comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="rule_id"/>
+        </constraint>
+        <index referenceId="MAGEOS_CATALOGAI_EXTRACT_RULE_TARGET" indexType="btree">
+            <column name="target_attribute"/>
+        </index>
+        <index referenceId="MAGEOS_CATALOGAI_EXTRACT_RULE_IS_ACTIVE" indexType="btree">
+            <column name="is_active"/>
+        </index>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -24,5 +24,28 @@
             "IDX_CATALOGAI_ENRICHMENT_STATUS": true,
             "IDX_CATALOGAI_ENRICHMENT_CREATED_AT": true
         }
+    },
+    "mageos_catalogai_extraction_rule": {
+        "column": {
+            "rule_id": true,
+            "name": true,
+            "source_attributes": true,
+            "target_attribute": true,
+            "extraction_prompt": true,
+            "value_mapping": true,
+            "conditions_serialized": true,
+            "store_ids": true,
+            "priority": true,
+            "is_active": true,
+            "created_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        },
+        "index": {
+            "MAGEOS_CATALOGAI_EXTRACT_RULE_TARGET": true,
+            "MAGEOS_CATALOGAI_EXTRACT_RULE_IS_ACTIVE": true
+        }
     }
 }

--- a/view/adminhtml/layout/catalogai_extractionrule_edit.xml
+++ b/view/adminhtml/layout/catalogai_extractionrule_edit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_extraction_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_extractionrule_index.xml
+++ b/view/adminhtml/layout/catalogai_extractionrule_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_extraction_rule_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalogai_extractionrule_new.xml
+++ b/view/adminhtml/layout/catalogai_extractionrule_new.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="mageos_catalogai_extraction_rule_form"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/ui_component/mageos_catalogai_extraction_rule_form.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_extraction_rule_form.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_extraction_rule_form.mageos_catalogai_extraction_rule_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Extraction Rule</item>
+        <item name="template" xsi:type="string">templates/form/collapsible</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="back">
+                <url path="*/*/"/>
+                <class>back</class>
+                <label translate="true">Back</label>
+            </button>
+            <button name="delete" class="MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit\DeleteButton"/>
+            <button name="save" class="MageOS\CatalogDataAI\Block\Adminhtml\ExtractionRule\Edit\SaveButton"/>
+        </buttons>
+        <namespace>mageos_catalogai_extraction_rule_form</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>mageos_catalogai_extraction_rule_form.mageos_catalogai_extraction_rule_form_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_extraction_rule_form_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="catalogai/extractionrule/save"/>
+        </settings>
+        <dataProvider class="MageOS\CatalogDataAI\Model\ExtractionRule\DataProvider" name="mageos_catalogai_extraction_rule_form_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general">
+        <settings>
+            <label translate="true">Rule Information</label>
+        </settings>
+        <field name="rule_id" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+            </settings>
+        </field>
+        <field name="name" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Rule Name</label>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="is_active" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="default" xsi:type="number">1</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Active</label>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="number">0</map>
+                            <map name="true" xsi:type="number">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+        <field name="source_attributes" formElement="multiselect">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Source Attributes</label>
+                <notice translate="true">Attributes to read data from (e.g., description, short_description).</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+            <formElements>
+                <multiselect>
+                    <settings>
+                        <options class="MageOS\CatalogDataAI\Model\Config\Source\EnrichableAttributes"/>
+                    </settings>
+                </multiselect>
+            </formElements>
+        </field>
+        <field name="target_attribute" formElement="input">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Target Attribute Code</label>
+                <notice translate="true">The attribute to fill (e.g., color, size, brand). Supports any frontend input type.</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="store_ids" formElement="multiselect">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Store Views</label>
+            </settings>
+            <formElements>
+                <multiselect>
+                    <settings>
+                        <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
+                    </settings>
+                </multiselect>
+            </formElements>
+        </field>
+        <field name="priority" formElement="input">
+            <settings>
+                <dataType>number</dataType>
+                <label translate="true">Priority</label>
+                <notice translate="true">Higher value = higher priority.</notice>
+            </settings>
+        </field>
+    </fieldset>
+    <fieldset name="extraction_fieldset">
+        <settings>
+            <label translate="true">Extraction</label>
+        </settings>
+        <field name="extraction_prompt" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Extraction Prompt</label>
+                <notice translate="true">Tell the AI what to extract. Use {{attribute_code}} placeholders. Example: "Extract the primary color from this product description."</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="value_mapping" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Value Mapping (JSON)</label>
+                <notice translate="true">For dropdown/multiselect targets: map AI output to option IDs. Example: {"Red": "42", "Blue": "43", "Green": "44"}</notice>
+            </settings>
+        </field>
+    </fieldset>
+</form>

--- a/view/adminhtml/ui_component/mageos_catalogai_extraction_rule_listing.xml
+++ b/view/adminhtml/ui_component/mageos_catalogai_extraction_rule_listing.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">mageos_catalogai_extraction_rule_listing.mageos_catalogai_extraction_rule_listing_data_source</item>
+        </item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="add">
+                <url path="catalogai/extractionrule/new"/>
+                <class>primary</class>
+                <label translate="true">Add New Extraction Rule</label>
+            </button>
+        </buttons>
+        <spinner>mageos_catalogai_extraction_rule_columns</spinner>
+        <deps>
+            <dep>mageos_catalogai_extraction_rule_listing.mageos_catalogai_extraction_rule_listing_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="mageos_catalogai_extraction_rule_listing_data_source" component="Magento_Ui/js/grid/provider">
+        <settings>
+            <updateUrl path="mui/index/render"/>
+        </settings>
+        <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="mageos_catalogai_extraction_rule_listing_data_source">
+            <settings>
+                <requestFieldName>rule_id</requestFieldName>
+                <primaryFieldName>rule_id</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <settings>
+            <sticky>true</sticky>
+        </settings>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters"/>
+        <paging name="listing_paging"/>
+    </listingToolbar>
+    <columns name="mageos_catalogai_extraction_rule_columns">
+        <column name="rule_id">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">ID</label>
+                <sorting>asc</sorting>
+            </settings>
+        </column>
+        <column name="name">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Name</label>
+            </settings>
+        </column>
+        <column name="source_attributes">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Source</label>
+            </settings>
+        </column>
+        <column name="target_attribute">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">Target</label>
+            </settings>
+        </column>
+        <column name="priority">
+            <settings>
+                <filter>textRange</filter>
+                <label translate="true">Priority</label>
+            </settings>
+        </column>
+        <column name="is_active" component="Magento_Ui/js/grid/columns/select">
+            <settings>
+                <filter>select</filter>
+                <label translate="true">Active</label>
+                <dataType>select</dataType>
+                <options class="Magento\Config\Model\Config\Source\Yesno"/>
+            </settings>
+        </column>
+        <actionsColumn name="actions" class="MageOS\CatalogDataAI\Ui\Component\Listing\Column\ExtractionRuleActions">
+            <settings>
+                <indexField>rule_id</indexField>
+            </settings>
+        </actionsColumn>
+    </columns>
+</listing>

--- a/view/adminhtml/ui_component/product_listing.xml
+++ b/view/adminhtml/ui_component/product_listing.xml
@@ -24,6 +24,17 @@
                     <label translate="true">AI Enrich(Safe)</label>
                 </settings>
             </action>
+            <action name="extract_attributes">
+                <settings>
+                    <confirm>
+                        <message translate="true">Run AI attribute extraction on selected products? Results will be held for review.</message>
+                        <title translate="true">Extract Attributes</title>
+                    </confirm>
+                    <url path="catalogai/product/massExtract"/>
+                    <type>extract_attributes</type>
+                    <label translate="true">AI Extract Attributes</label>
+                </settings>
+            </action>
         </massaction>
     </listingToolbar>
 </listing>


### PR DESCRIPTION
## Summary

Fixes #7. Supersedes #56 (the original Phase 5 bundle, now cleanly rebased onto the post-merge main).

Adds a new enrichment type alongside the existing content generation: **extract structured values from unstructured text**. Admins define extraction rules that read source attributes (like description), ask the AI to pull a specific value, and map the response to a dropdown/multiselect/boolean/numeric attribute.

## Why it's different from prompt rules

Content generation and attribute extraction are fundamentally different prompt-engineering problems:

- **Generation** asks the model to create prose. Output is text.
- **Extraction** asks the model to classify or pull a value. Output is a typed value with deterministic mapping to Magento option IDs.

They live as separate admin rule sets because the prompt shape, validation, and result handling differ.

## What's new

**Data layer:**
- `mageos_catalogai_extraction_rule` table with columns for source/target attribute codes, extraction prompt, JSON value mapping, store scope, priority, conditions, active flag

**Service (`AttributeExtractor`):**
- Loads active rules ordered by priority, first matching rule per target attribute wins
- Calls OpenAI with `response_format: {type: 'json_object'}` for deterministic structured output
- AI returns `{"value": "..."}`, parsed without regex
- Value mapping and validation:
  - Dropdown/multiselect: maps AI output to Magento option IDs (exact case-insensitive match → fuzzy label match → existing option label fallback)
  - Boolean: normalizes yes/true/1 → 1, no/false/0 → 0
  - Price/weight: validates numeric
  - Text/textarea: passes through
  - Invalid values logged as warnings, not written

**Admin UI:**
- New "AI Extraction Rules" menu entry under Catalog
- Full CRUD: grid listing, edit form, mass-delete
- Conditions fieldset uses the same catalog-rule framework as the prompt rules engine (#32 / #63)

**Mass action:**
- "AI Extract Attributes" action on the product grid queues selected products for extraction via the existing async publisher

## Test plan

- [x] 151 unit tests, 316 assertions, green locally (CI will confirm on PHP 8.2/8.3/8.4)
- [ ] Run \`setup:upgrade\` — creates \`mageos_catalogai_extraction_rule\` table
- [ ] Navigate to **Catalog → AI Extraction Rules** — grid loads
- [ ] Create a rule: source=description, target=color, prompt=\"Extract the primary color\", mapping=\`{\"Red\": \"42\", \"Blue\": \"43\"}\`
- [ ] Product grid shows \"AI Extract Attributes\" mass action
- [ ] Run extraction, verify value mapping resolves correctly (exact, case-insensitive, fuzzy)
- [ ] Boolean/numeric validation rejects invalid values with a warning log